### PR TITLE
Demo: Set `PlatformTarget` to AnyCPU allow running the demo on

### DIFF
--- a/src/ShadUI.Demo/ShadUI.Demo.csproj
+++ b/src/ShadUI.Demo/ShadUI.Demo.csproj
@@ -13,7 +13,7 @@
         <ApplicationManifest>app.manifest</ApplicationManifest>
         <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
         <ApplicationIcon>Assets\favicon.ico</ApplicationIcon>
-        <PlatformTarget>x64</PlatformTarget>
+        <PlatformTarget>AnyCPU</PlatformTarget>
         <Platforms>AnyCPU;x64</Platforms>
         <PrepareForRunDependsOn>$(PrepareForRunDependsOn);GenerateXamlTextCopies;GenerateCSharpTextCopies</PrepareForRunDependsOn>
     </PropertyGroup>


### PR DESCRIPTION
apple silicon.

Tested on m4 mac:
```
cd src/ShadUI.Demo
dotnet restore
dotnet run -r osx-arm64
```