### PR TITLE
feat(dialog, toast): API extension for toast types and returning asynchronous results from dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# IDE
+.vs/
+*.user
+*.suo
+
+# Build output
+bin/
+obj/
+*.exe
+*.dll
+*.pdb
+
+# Avalonia/MAUI/VS tooling cache
+*.db
+*.cache
+*.log
+
+# Rider
+.idea/
+
+# Windows
+Thumbs.db
+desktop.ini
+
+# Misc
+*.wapproj.user
+*.assets.cache

--- a/src/ShadUI.Demo/ViewModels/DialogViewModel.cs
+++ b/src/ShadUI.Demo/ViewModels/DialogViewModel.cs
@@ -1,7 +1,8 @@
-﻿using System;
-using System.IO;
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace ShadUI.Demo.ViewModels;
 
@@ -28,6 +29,7 @@ public sealed partial class DialogViewModel : ViewModelBase, INavigable
         AlertDialogCode = WrapCode(path.ExtractByLineRange(62, 78).CleanIndentation());
         DestructiveAlertDialogCode = WrapCode(path.ExtractByLineRange(83, 100).CleanIndentation());
         CustomDialogCode = WrapCode(path.ExtractByLineRange(105, 122).CleanIndentation());
+        CustomDialogCodeWithResult = WrapCode(path.ExtractByLineRange(126, 154).CleanIndentation());
     }
 
     [RelayCommand]
@@ -119,5 +121,35 @@ public sealed partial class DialogViewModel : ViewModelBase, INavigable
                     .DismissOnClick()
                     .ShowWarning())
             .Show();
+    }
+
+    [ObservableProperty]
+    private string _customDialogCodeWithResult = string.Empty;
+
+    [RelayCommand]
+    private async Task ShowCustomDialogWithResult()
+    {
+        _loginViewModel.Initialize();
+
+        var result = await _dialogManager.CreateDialog(_loginViewModel)
+            .Dismissible()
+            .WithSuccessCallback(() =>
+                _toastManager.CreateToast("Sign in successful")
+                    .WithContent("Welcome back!")
+                    .DismissOnClick()
+                    .ShowSuccess())
+            .WithCancelCallback(() =>
+                _toastManager.CreateToast("Sign in cancelled")
+                    .WithContent("Please sign in to continue.")
+                    .DismissOnClick()
+                    .ShowWarning())
+            .ShowDialogAsync<string>();
+
+
+        if (result != null)
+            _toastManager.CreateToast($"Respose")
+            .WithContent($"{result}")
+            .DismissOnClick()
+            .ShowSuccess();
     }
 }

--- a/src/ShadUI.Demo/ViewModels/LoginViewModel.cs
+++ b/src/ShadUI.Demo/ViewModels/LoginViewModel.cs
@@ -46,7 +46,14 @@ public sealed partial class LoginViewModel(DialogManager dialogManager) : ViewMo
         ValidateAllProperties();
 
         if (HasErrors) return;
-        dialogManager.Close(this, new CloseDialogOptions { Success = true });
+
+        var options = new CloseDialogOptions
+        {
+            Success = true,
+            Result = $"Hello - {Email}"
+        };
+
+        dialogManager.Close(this, options);
     }
 
     [RelayCommand]

--- a/src/ShadUI.Demo/ViewModels/ToastViewModel.cs
+++ b/src/ShadUI.Demo/ViewModels/ToastViewModel.cs
@@ -1,7 +1,8 @@
-﻿using System;
-using System.IO;
-using CommunityToolkit.Mvvm.ComponentModel;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using System;
+using System.Collections.ObjectModel;
+using System.IO;
 
 namespace ShadUI.Demo.ViewModels;
 
@@ -24,6 +25,7 @@ public sealed partial class ToastViewModel : ViewModelBase, INavigable
         SuccessToastCode = WrapCode(path.ExtractByLineRange(110, 117).CleanIndentation());
         WarningToastCode = WrapCode(path.ExtractByLineRange(122, 129).CleanIndentation());
         ErrorToastCode = WrapCode(path.ExtractByLineRange(134, 141).CleanIndentation());
+        CustomTypeToastCode = WrapCode(path.ExtractByLineRange(145, 173).CleanIndentation());
     }
 
     [RelayCommand]
@@ -142,4 +144,31 @@ public sealed partial class ToastViewModel : ViewModelBase, INavigable
 
     [ObservableProperty]
     private string _errorToastCode = string.Empty;
+
+    [ObservableProperty]
+    private ObservableCollection<Notification> _notificationsCollection =
+    [
+        Notification.Basic,
+            Notification.Info,
+            Notification.Success,
+            Notification.Warning,
+            Notification.Error
+    ];
+
+    [ObservableProperty]
+    private Notification _selectedNotification;
+
+    [ObservableProperty]
+    private string _customTypeToastCode = string.Empty;
+
+    [RelayCommand]
+    private void ShowToastWithType()
+    {
+        _toastManager.CreateToast("Your message has been sent.")
+            .WithContent($"{DateTime.Now:dddd, MMMM d 'at' h:mm tt}")
+            .WithAction("Retry", () => _toastManager.CreateToast("Retry clicked")
+            .ShowType(Notification.Success))
+            .DismissOnClick()
+            .ShowType(SelectedNotification);
+    }
 }

--- a/src/ShadUI.Demo/Views/DialogPage.axaml
+++ b/src/ShadUI.Demo/Views/DialogPage.axaml
@@ -158,6 +158,15 @@
                             Content="Show Dialog" />
                     </StackPanel>
                 </controls:ControlBlock>
+                <controls:ControlBlock Title="Custom Dialog With Result" CSharp="{Binding CustomDialogCodeWithResult}">
+                  <StackPanel>
+                    <Button
+                        HorizontalAlignment="Center"
+                        Classes="Outline"
+                        Command="{Binding ShowCustomDialogWithResultCommand}"
+                        Content="Show Dialog" />
+                  </StackPanel>
+                </controls:ControlBlock>
             </StackPanel>
         </ScrollViewer>
     </DockPanel>

--- a/src/ShadUI.Demo/Views/ToastPage.axaml
+++ b/src/ShadUI.Demo/Views/ToastPage.axaml
@@ -181,6 +181,20 @@
                             Content="Show Toast" />
                     </StackPanel>
                 </controls:ControlBlock>
+                <controls:ControlBlock Title="With Selected NotificationType Toast" CSharp="{Binding CustomTypeToastCode}">
+                  <StackPanel
+                      HorizontalAlignment="Center"
+                      Orientation="Horizontal"
+                      Spacing="8">
+                    <ComboBox Width="255" ItemsSource="{Binding NotificationsCollection, Mode=OneWay}"
+                              SelectedItem="{Binding SelectedNotification, Mode=TwoWay}"/>
+                    <Button
+                        HorizontalAlignment="Center"
+                        Classes="Outline"
+                        Command="{Binding ShowToastWithTypeCommand}"
+                        Content="Show Toast" />
+                  </StackPanel>
+                </controls:ControlBlock>
             </StackPanel>
         </ScrollViewer>
     </DockPanel>

--- a/src/ShadUI/Controls/Dialog/CloseDialogOptions.cs
+++ b/src/ShadUI/Controls/Dialog/CloseDialogOptions.cs
@@ -15,4 +15,14 @@ public sealed class CloseDialogOptions
     ///     Specifies whether all dialogs should be cleared when closing this dialog.
     /// </summary>
     public bool ClearAll { get; set; }
+
+    /// <summary>
+    ///     The result object to return when the dialog is closed.
+    /// </summary>
+    public object? Result { get; set; }
+
+    /// <summary>
+    ///     Indicates whether the dialog was canceled (e.g., via cancellation token).
+    /// </summary>
+    public bool Canceled { get; set; } = false;
 }

--- a/src/ShadUI/Controls/Dialog/DialogBuilder.cs
+++ b/src/ShadUI/Controls/Dialog/DialogBuilder.cs
@@ -1,6 +1,7 @@
-using System;
-using System.Threading.Tasks;
 using Avalonia.Controls;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 // ReSharper disable once CheckNamespace
 namespace ShadUI;
@@ -12,6 +13,14 @@ namespace ShadUI;
 public sealed class DialogBuilder<TContext>
 {
     private readonly DialogManager _manager;
+
+    /// <summary>
+    ///     Gets the dialog context (DataContext of the dialog control).
+    /// </summary>
+    /// <exception cref="InvalidOperationException">
+    ///     Thrown if the dialog control has not been created or set.
+    /// </exception>
+    private TContext Context => (TContext)((_control?.DataContext) ?? throw new InvalidOperationException("Dialog control is not set."));
 
     internal DialogBuilder(DialogManager manager)
     {
@@ -66,5 +75,36 @@ public sealed class DialogBuilder<TContext>
         }
 
         _manager.Show(_control, Options);
+    }
+
+    /// <summary>
+    ///     Shows the dialog and returns the result asynchronously.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result returned from the dialog.</typeparam>
+    /// <returns>
+    ///     A <see cref="Task{TResult}"/> representing the asynchronous operation,
+    ///     containing the result of type <typeparamref name="TResult"/> or <c>null</c>.
+    /// </returns>
+    public Task<TResult?> ShowDialogAsync<TResult>()
+    {
+        var context = Context;
+        Show(); // automatic call Show
+        return _manager.ShowDialogAsync<TResult, TContext>(context);
+    }
+
+    /// <summary>
+    ///     Shows the dialog with support for cancellation and returns the result asynchronously.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result returned from the dialog.</typeparam>
+    /// <param name="cancellationToken">A token to observe while waiting for the task to complete.</param>
+    /// <returns>
+    ///     A <see cref="Task{TResult}"/> representing the asynchronous operation,
+    ///     containing the result of type <typeparamref name="TResult"/> or <c>null</c>.
+    /// </returns>
+    public Task<TResult?> ShowDialogAsync<TResult>(CancellationToken cancellationToken)
+    {
+        var context = Context;
+        Show(); // automatic call Show
+        return _manager.ShowDialogAsync<TResult, TContext>(context, cancellationToken);
     }
 }

--- a/src/ShadUI/Controls/Dialog/DialogHost.axaml.cs
+++ b/src/ShadUI/Controls/Dialog/DialogHost.axaml.cs
@@ -212,8 +212,28 @@ public class DialogHost : TemplatedControl
 
         IsDialogOpen = false;
 
-        Manager?.RemoveLast();
-        Manager?.OpenLast();
+        if (Manager is null || Dialog is not Control dialogControl) return;
+
+        var context = dialogControl.DataContext;
+        if (context is not null)
+        {
+            // Completes the TaskCompletionSource associated with the dialog context,
+            // triggers success or cancellation callbacks,
+            // and removes the dialog from the open dialogs collection.
+            Manager.Close(context, new CloseDialogOptions
+            {
+                Success = false,
+                Result = default
+            });
+        }
+        else
+        {
+            // Fallback to legacy behavior:
+            // removes the last opened dialog and reopens the previous one,
+            // to avoid UI deadlocks or orphan dialogs when no context is available.
+            Manager.RemoveLast();
+            Manager.OpenLast();
+        }
 
         if (Owner is not null) Owner.HasOpenDialog = false;
     }

--- a/src/ShadUI/Controls/Dialog/DialogManager.cs
+++ b/src/ShadUI/Controls/Dialog/DialogManager.cs
@@ -1,8 +1,10 @@
-﻿using System;
+﻿using Avalonia.Controls;
+using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-using Avalonia.Controls;
 
 // ReSharper disable once CheckNamespace
 namespace ShadUI;
@@ -16,6 +18,12 @@ public sealed class DialogManager
     internal event EventHandler<DialogClosedEventArgs>? OnDialogClosed;
 
     internal readonly Dictionary<Control, DialogOptions> Dialogs = [];
+
+    /// <summary>
+    ///     Stores the mapping between dialog contexts and their <see cref="TaskCompletionSource{TResult}"/>,
+    ///     used for asynchronously awaiting dialog results.
+    /// </summary>
+    private readonly ConcurrentDictionary<object, TaskCompletionSource<object?>> _resultSources = new();
 
     /// <summary>
     ///     Shows a dialog with the provided options.
@@ -50,15 +58,68 @@ public sealed class DialogManager
         OnDialogShown?.Invoke(this, new DialogShownEventArgs { Control = control, Options = options });
     }
 
+    /// <summary>
+    /// Shows a dialog asynchronously with the specified context and returns a result of type <typeparamref name="TResult"/>.
+    /// </summary>
+    /// <typeparam name="TResult">The type of the result returned by the dialog.</typeparam>
+    /// <typeparam name="TContext">The type of the dialog context.</typeparam>
+    /// <param name="context">The context object associated with the dialog.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the dialog operation.</param>
+    /// <returns>A task that completes with the dialog result of type <typeparamref name="TResult"/>, or <c>null</c> if no result is provided.</returns>
+    /// <exception cref="InvalidOperationException">Thrown if a dialog with the specified context is already shown.</exception>
+    public Task<TResult?> ShowDialogAsync<TResult, TContext>(TContext context, CancellationToken cancellationToken = default)
+    {
+        // Create a TaskCompletionSource to await the dialog result asynchronously.
+        // Use RunContinuationsAsynchronously to ensure continuations run asynchronously.
+        var tcs = new TaskCompletionSource<object?>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Try to add the context and its TaskCompletionSource to the internal dictionary.
+        // Throws if a dialog with the same context is already being shown.
+        if (!_resultSources.TryAdd(context!, tcs))
+            throw new InvalidOperationException("Dialog for this context is already shown.");
+
+        // If a cancellation token is provided, register a callback to cancel the dialog.
+        if (cancellationToken != default)
+        {
+            cancellationToken.Register(() =>
+            {
+                // Attempt to remove the TaskCompletionSource for the context and cancel the task.
+                if (_resultSources.TryRemove(context!, out var source))
+                {
+                    source.TrySetCanceled();
+                    // Close the dialog associated with the context.
+                    Close(context!);
+                }
+            });
+        }
+
+        // Create and show the dialog for the given context, making it dismissible by default.
+        this.CreateDialog(context).Dismissible().Show();
+
+        // Return a task that completes when the dialog finishes.
+        // On completion, remove the context from the dictionary.
+        // If the task was cancelled, throw TaskCanceledException.
+        // Otherwise, cast the result to TResult or return default.
+        return tcs.Task.ContinueWith(task =>
+        {
+            _resultSources.TryRemove(context!, out _);
+
+            if (task.IsCanceled)
+                throw new TaskCanceledException(task);
+
+            return task.Result is TResult result ? result : default;
+        }, TaskScheduler.Current);
+    }
+
     internal void CloseDialog(Control control)
     {
         Dialogs.Remove(control);
 
         OnDialogClosed?.Invoke(this, new DialogClosedEventArgs
-            {
-                ReplaceExisting = Dialogs.Count > 0,
-                Control = control
-            }
+        {
+            ReplaceExisting = Dialogs.Count > 0,
+            Control = control
+        }
         );
     }
 
@@ -141,6 +202,18 @@ public sealed class DialogManager
         var success = options?.Success ?? false;
         InvokeCallBacks(typeof(TContext), success);
 
+        // Try to remove the TaskCompletionSource associated with the dialog context.
+        // If found, set the task result or cancel it based on the provided options.
+        // If 'Canceled' is true, the task is marked as canceled.
+        // Otherwise, the task is completed with the specified result (which may be null).
+        if (_resultSources.TryRemove(context!, out var tcs))
+        {
+            if (options != null && options.Canceled)
+                tcs.TrySetCanceled();
+            else
+                tcs.TrySetResult(options?.Result);
+        }
+
         if (!clearAll) OpenLast();
     }
 
@@ -184,4 +257,10 @@ internal sealed class DialogClosedEventArgs : EventArgs
 {
     public bool ReplaceExisting { get; set; }
     public Control Control { get; set; } = null!;
+
+    /// <summary>
+    ///     The result returned when the dialog is closed.
+    ///     This value is passed through <see cref="CloseDialogOptions.Result"/>.
+    /// </summary>
+    public object? Result { get; set; }
 }

--- a/src/ShadUI/Controls/Toast/ToastBuilderExtensions.cs
+++ b/src/ShadUI/Controls/Toast/ToastBuilderExtensions.cs
@@ -193,4 +193,15 @@ public static class ToastBuilderExtensions
         builder.Notification = Notification.Error;
         builder.Show();
     }
+
+    /// <summary>
+    ///     Shows a toast notification in the specified style.
+    /// </summary>
+    /// <param name="builder"></param>
+    /// <param name="type">Notification type sent</param>
+    public static void ShowType(this ToastBuilder builder, Notification type)
+    {
+        builder.Notification = type;
+        builder.Show();
+    }
 }


### PR DESCRIPTION
feat(toast): add support for showing toast with selected notification type
- added `ShowType(Notification)` extension method to `ToastBuilder`
- added `ComboBox` in demo to choose Notification type (Basic, Info, etc.)
- added `ShowToastWithTypeCommand` to demonstrate the new behavior

feat(dialog): add support for async dialog result handling
- added `Result` and `Canceled` properties to `CloseDialogOptions`
- extended `DialogManager` with `ShowDialogAsync<TResult, TContext>` method
- added `ShowDialogAsync<TResult>` and `ShowDialogAsync<TResult>(CancellationToken)` to `DialogBuilder<TContext>`
- enabled dialog result completion via context binding in `DialogHost`
- updated `DialogClosedEventArgs` with `Result` for completeness
- added demo usage: `ShowCustomDialogWithResultCommand` in `DialogViewModel` and UI on `DialogPage`