### PR TITLE
Fix incomplete source code display in GroupedDataTableViewModel example

### DIFF
--- a/src/ShadUI.Demo/ViewModels/Examples/DataTable/GroupedDataTableViewModel.cs
+++ b/src/ShadUI.Demo/ViewModels/Examples/DataTable/GroupedDataTableViewModel.cs
@@ -16,7 +16,7 @@ public sealed partial class GroupedDataTableViewModel : ViewModelBase
 
         var csharpPath = Path.Combine(AppContext.BaseDirectory, "viewModels", "Examples", "DataTable",
             "GroupedDataTableViewModel.cs");
-        CSharpCode = csharpPath.ExtractWithSkipRanges((31, 36), (48, 53)).CleanIndentation();
+		CSharpCode = csharpPath.ExtractByLineRange(1, 71).CleanIndentation();
 
         var people = new List<Person>
         {


### PR DESCRIPTION
### Problem
In the C# source code viewer for `GroupedDataTable` example, I notice that it was skipping crucial lines of code due to `ExtractWithSkipRanges((31, 36), (48, 53))`. I have to look back and forth to confirm if it was just a mistake. This resulted in missing how to add group descriptions, specifically:
```cs
var view = new DataGridCollectionView(people);
view.GroupDescriptions.Add(new DataGridPathGroupDescription("State"));
GroupedPeople = view;
```
### Solution
Replace `ExtractWithSkipRanges()` to `ExtractByLineRange(1, 71)` to display the complete source code without any line skipping.

### Before
<img width="568" height="379" alt="before-fix" src="https://github.com/user-attachments/assets/f1fa571f-1351-4330-a9ad-c0cbc06ae5eb" />

### After
<img width="698" height="491" alt="after-fix" src="https://github.com/user-attachments/assets/57b0a7e5-9179-426c-8487-6d3277c66482" />
