### PR TITLE
Fix segmentation fault in Demo project on Linux

### DIFF
--- a/src/ShadUI.Demo/Views/DashboardPage.axaml.cs
+++ b/src/ShadUI.Demo/Views/DashboardPage.axaml.cs
@@ -1,5 +1,6 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using LiveChartsCore.Kernel;
 using ShadUI.Demo.ViewModels;
 
@@ -31,9 +32,12 @@ public partial class DashboardPage : UserControl
 
     private void OnThemeChanged(object? sender, ThemeColors e)
     {
-        CartesianChart1.CoreChart.Update(new ChartUpdateParams
-            { IsAutomaticUpdate = false, Throttling = false });
-        CartesianChart2.CoreChart.Update(new ChartUpdateParams
-            { IsAutomaticUpdate = false, Throttling = false });
+        Dispatcher.UIThread.Post(() =>
+        {
+            CartesianChart1.CoreChart.Update(new ChartUpdateParams 
+                { IsAutomaticUpdate = false, Throttling = false });
+            CartesianChart2.CoreChart.Update(new ChartUpdateParams 
+                { IsAutomaticUpdate = false, Throttling = false });
+        });
     }
 }


### PR DESCRIPTION
**Summary:**
This PR fixes segmentation fault in Demo project on Linux by updating `DashboardPage`'s charts in the following frame after theme changes.

**Description:**
After some investigation, I managed to fix #40. The segmentation fault was caused by the `DashboardPage.OnThemeChanged` function, specifically by updating charts immediately after the theme had changed. It appears that the `ThemeChanged` callback (precisely, the `UpdateAxesLabelPaints` and `UpdateSeriesFill` functions), defined in `DashboardViewModel.DashboardViewModel`, triggers an internal `skia` state update, which finishes at the end of the frame (or at the beginning of the next frame?). Because of this, such data as fonts may be invalid during the `DashboardPage.OnThemeChanged` call.

So the solution is to update charts in the next frame, which can be done using the `Dispatcher.UIThread.Post` function.