### PR TITLE
feat(controls): add MarqueeTextBlock control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,121 @@
+########################################
+# OS-specific
+########################################
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+$RECYCLE.BIN/
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+Icon?
+._*
+.Spotlight-V100
+.Trashes
+
+########################################
+# Visual Studio / .NET
+########################################
+
+# Build results
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+
+# Visual Studio files
+.vs/
+*.user
+*.userosscache
+*.suo
+*.cache
+*.docstates
+
+# Visual Studio Code (optional)
+.vscode/
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+
+########################################
+# Rider / JetBrains
+########################################
+
+.idea/
+*.sln.iml
+*.DotSettings.user
+_ReSharper*/
+*.[Rr]e[Ss]harper
+*.resharper.user
+
+########################################
+# .NET Core / SDK
+########################################
+
+# Project lock & runtime files
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# NuGet
+*.nupkg
+*.snupkg
+.nuget/
+packages/
+.nuget/packages/
+
+# dotnet tools
+.dotnet/
+.dotnet-tools.json
+
+########################################
+# Testing
+########################################
+
+# Test results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# Coverage
+coverage/
+coverage.*
+*.coverage
+*.coveragexml
+
+########################################
+# Publishing
+########################################
+
+# Publish output
+publish/
+app.publish/
+
+########################################
+# Azure / Cloud / Containers (optional)
+########################################
+
+# Azure
+.azure/
+
+# Docker
+docker-compose.override.yml
+
+########################################
+# Misc
+########################################
+
+# Backup files
+*.bak
+*.tmp
+*.temp
+*.old
+
+# Rider / VS caches
+*.pidb
+*.svclog
+*.scc

--- a/ShadUI.Mac.sln
+++ b/ShadUI.Mac.sln
@@ -1,0 +1,108 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35707.178
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShadUI", "src\ShadUI\ShadUI.csproj", "{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{EB1792AF-C6EF-490D-9F17-AE4E72F108DD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShadUI.Demo", "src\ShadUI.Demo\ShadUI.Demo.csproj", "{7B2C2DCA-8E60-475C-A590-07CB1897FE31}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{BDF88755-E2E7-438D-A15D-DFDA0FB3836F}"
+	ProjectSection(SolutionItems) = preProject
+		docs\demo-01.gif = docs\demo-01.gif
+		docs\demo-02.gif = docs\demo-02.gif
+		docs\demo-03.gif = docs\demo-03.gif
+		docs\demo-04.gif = docs\demo-04.gif
+		docs\hero.png = docs\hero.png
+	EndProjectSection
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|ARM = Debug|ARM
+		Debug|ARM64 = Debug|ARM64
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|ARM = Release|ARM
+		Release|ARM64 = Release|ARM64
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Debug|ARM.Build.0 = Debug|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Debug|x64.ActiveCfg = Release|x64
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Debug|x64.Build.0 = Release|x64
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Debug|x86.Build.0 = Debug|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Release|ARM.ActiveCfg = Release|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Release|ARM.Build.0 = Release|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Release|ARM64.Build.0 = Release|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Release|x64.ActiveCfg = Release|x64
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Release|x64.Build.0 = Release|x64
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Release|x86.ActiveCfg = Release|Any CPU
+		{7F5BD55E-CE7F-4746-A993-2C0ADD4152B7}.Release|x86.Build.0 = Release|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Debug|ARM.Build.0 = Debug|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Debug|x64.ActiveCfg = Release|x64
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Debug|x64.Build.0 = Release|x64
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Debug|x86.Build.0 = Debug|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Release|ARM.ActiveCfg = Release|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Release|ARM.Build.0 = Release|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Release|ARM64.Build.0 = Release|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Release|x64.ActiveCfg = Release|x64
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Release|x64.Build.0 = Release|x64
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Release|x86.ActiveCfg = Release|Any CPU
+		{7B2C2DCA-8E60-475C-A590-07CB1897FE31}.Release|x86.Build.0 = Release|Any CPU
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Debug|ARM.ActiveCfg = Debug|ARM
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Debug|ARM.Build.0 = Debug|ARM
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Debug|ARM.Deploy.0 = Debug|ARM
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Debug|ARM64.ActiveCfg = Debug|ARM64
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Debug|ARM64.Build.0 = Debug|ARM64
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Debug|ARM64.Deploy.0 = Debug|ARM64
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Debug|x64.ActiveCfg = Release|x64
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Debug|x86.ActiveCfg = Debug|x86
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Debug|x86.Build.0 = Debug|x86
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Debug|x86.Deploy.0 = Debug|x86
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|ARM.ActiveCfg = Release|ARM
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|ARM.Build.0 = Release|ARM
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|ARM.Deploy.0 = Release|ARM
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|ARM64.ActiveCfg = Release|ARM64
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|ARM64.Build.0 = Release|ARM64
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|ARM64.Deploy.0 = Release|ARM64
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|x64.ActiveCfg = Release|x64
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|x64.Build.0 = Release|x64
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|x64.Deploy.0 = Release|x64
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|x86.ActiveCfg = Release|x86
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|x86.Build.0 = Release|x86
+		{FACFCC37-FB25-420A-89DF-CAC5915135C7}.Release|x86.Deploy.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5607F300-CEB5-47A3-AFF0-5FEA0CBBD9FF}
+	EndGlobalSection
+EndGlobal

--- a/src/ShadUI.Demo/MainWindow.axaml
+++ b/src/ShadUI.Demo/MainWindow.axaml
@@ -11,6 +11,8 @@
     x:Class="ShadUI.Demo.MainWindow"
     x:DataType="demo:MainWindowViewModel"
     x:Name="Window"
+    EnableTrafficLightPositioning="True"
+    TrafficLightOffset="5,8"
     xmlns="https://github.com/avaloniaui"
     xmlns:converters="clr-namespace:ShadUI.Demo.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"

--- a/src/ShadUI.Demo/MainWindow.axaml
+++ b/src/ShadUI.Demo/MainWindow.axaml
@@ -136,7 +136,23 @@
                     </shadui:SidebarItem>
                     <shadui:SidebarItemLabel
                         AsSeparator="True"
-                        Margin="8,20,8,8"
+                        Text="Behaviors" />
+                    <shadui:SidebarItem
+                        Command="{Binding OpenSmoothScrollCommand}"
+                        Content="Smooth Scroll"
+                        Route="smoothScroll"
+                        ToolTip.Tip="{Binding $parent[shadui:Sidebar].Expanded, Converter={x:Static converters:BooleanConverters.NullOrString}, ConverterParameter='Smooth Scroll'}">
+                        <shadui:SidebarItem.Icon>
+                            <Viewbox>
+                                <TextBlock
+                                    Classes="LucideIcon"
+                                    Foreground="{DynamicResource ForegroundColor}"
+                                    Text="&#58583;" />
+                            </Viewbox>
+                        </shadui:SidebarItem.Icon>
+                    </shadui:SidebarItem>
+                    <shadui:SidebarItemLabel
+                        AsSeparator="True"
                         Text="Components" />
                     <shadui:SidebarItem
                         Command="{Binding OpenAvatarCommand}"

--- a/src/ShadUI.Demo/MainWindowViewModel.cs
+++ b/src/ShadUI.Demo/MainWindowViewModel.cs
@@ -15,6 +15,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     private readonly DashboardViewModel _dashboardViewModel;
     private readonly ThemeViewModel _themeViewModel;
     private readonly TypographyViewModel _typographyViewModel;
+    private readonly SmoothScrollViewModel _smoothScrollViewModel;
     private readonly AvatarViewModel _avatarViewModel;
     private readonly BadgeViewModel _badgeViewModel;
     private readonly ButtonViewModel _buttonViewModel;
@@ -49,6 +50,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase
         DashboardViewModel dashboardViewModel,
         ThemeViewModel themeViewModel,
         TypographyViewModel typographyViewModel,
+        SmoothScrollViewModel smoothScrollViewModel,
         AvatarViewModel avatarViewModel,
         BadgeViewModel badgeViewModel,
         ButtonViewModel buttonViewModel,
@@ -79,6 +81,7 @@ public sealed partial class MainWindowViewModel : ViewModelBase
         _dashboardViewModel = dashboardViewModel;
         _themeViewModel = themeViewModel;
         _typographyViewModel = typographyViewModel;
+        _smoothScrollViewModel = smoothScrollViewModel;
         _avatarViewModel = avatarViewModel;
         _badgeViewModel = badgeViewModel;
         _buttonViewModel = buttonViewModel;
@@ -152,6 +155,12 @@ public sealed partial class MainWindowViewModel : ViewModelBase
     private void OpenTypography()
     {
         SwitchPage(_typographyViewModel);
+    }
+
+    [RelayCommand]
+    private void OpenSmoothScroll()
+    {
+        SwitchPage(_smoothScrollViewModel);
     }
 
     [RelayCommand]

--- a/src/ShadUI.Demo/ServiceProvider.cs
+++ b/src/ShadUI.Demo/ServiceProvider.cs
@@ -54,6 +54,7 @@ namespace ShadUI.Demo;
 [Transient<ToggleViewModel>]
 [Transient<ToolTipViewModel>]
 [Transient<TypographyViewModel>]
+[Transient<SmoothScrollViewModel>]
 [Transient<TextBlockViewModel>]
 [Transient<SelectableTextBlockViewModel>]
 [Transient<LabelViewModel>]

--- a/src/ShadUI.Demo/ShadUI.Demo.csproj
+++ b/src/ShadUI.Demo/ShadUI.Demo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFrameworks>net9.0; net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <Version>1.1.1</Version>
         <AssemblyName>shadui-app</AssemblyName>
@@ -23,22 +23,22 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.3.8" />
+        <PackageReference Include="Avalonia" Version="11.3.10" />
         <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.3.0"/>
-        <PackageReference Include="Avalonia.Desktop" Version="11.3.8" />
+        <PackageReference Include="Avalonia.Desktop" Version="11.3.10" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.8">
+        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.10">
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
             <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
         </PackageReference>
         <PackageReference Include="AvaloniaEdit.TextMate" Version="11.3.0"/>
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0"/>
-        <PackageReference Include="HotAvalonia" Version="3.0.0" PrivateAssets="All"/>
+        <PackageReference Include="HotAvalonia" Version="3.0.2" PrivateAssets="All" />
         <PackageReference Include="Jab" Version="0.12.0" PrivateAssets="All" />
         <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4"/>
         <PackageReference Include="Serilog" Version="4.3.0"/>
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0"/>
-        <PackageReference Include="TextMateSharp.Grammars" Version="1.0.70" />
+        <PackageReference Include="TextMateSharp.Grammars" Version="2.0.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ShadUI.Demo/ShadUI.Demo.csproj
+++ b/src/ShadUI.Demo/ShadUI.Demo.csproj
@@ -45,6 +45,13 @@
         <ProjectReference Include="..\ShadUI\ShadUI.csproj"/>
     </ItemGroup>
 
+    <ItemGroup>
+      <Compile Update="Views\SmoothScrollPage.axaml.cs">
+        <DependentUpon>SmoothScrollPage.axaml</DependentUpon>
+        <SubType>Code</SubType>
+      </Compile>
+    </ItemGroup>
+
     <Target Name="GenerateXamlTextCopies" BeforeTargets="PrepareForRun">
         <ItemGroup>
             <XamlFiles Include="Views\**\*.axaml"/>

--- a/src/ShadUI.Demo/ShadUI.Demo.csproj
+++ b/src/ShadUI.Demo/ShadUI.Demo.csproj
@@ -38,7 +38,7 @@
         <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4"/>
         <PackageReference Include="Serilog" Version="4.3.0"/>
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0"/>
-        <PackageReference Include="TextMateSharp.Grammars" Version="2.0.2" />
+        <PackageReference Include="TextMateSharp.Grammars" Version="1.0.70" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ShadUI.Demo/ShadUI.Demo.csproj
+++ b/src/ShadUI.Demo/ShadUI.Demo.csproj
@@ -57,9 +57,8 @@
             <XamlFiles Include="Views\**\*.axaml"/>
         </ItemGroup>
 
-        <Copy SourceFiles="@(XamlFiles)" 
-              
-              DestinationFiles="@(XamlFiles->'$(OutDir)views/%(RecursiveDir)%(Filename).axaml')" 
+        <Copy SourceFiles="@(XamlFiles)"
+              DestinationFiles="@(XamlFiles->'$(OutDir)views/%(RecursiveDir)%(Filename).axaml')"
               SkipUnchangedFiles="true"/>
     </Target>
 
@@ -68,9 +67,8 @@
             <CSharpFiles Include="ViewModels\**\*.cs" Exclude="ViewModels\ViewModelBase.cs"/>
         </ItemGroup>
 
-        <Copy SourceFiles="@(CSharpFiles)" 
-              
-              DestinationFiles="@(CSharpFiles->'$(OutDir)viewModels/%(RecursiveDir)%(Filename).cs')" 
+        <Copy SourceFiles="@(CSharpFiles)"
+              DestinationFiles="@(CSharpFiles->'$(OutDir)viewModels/%(RecursiveDir)%(Filename).cs')"
               SkipUnchangedFiles="true"/>
     </Target>
 </Project>

--- a/src/ShadUI.Demo/ShadUI.Demo.csproj
+++ b/src/ShadUI.Demo/ShadUI.Demo.csproj
@@ -19,30 +19,30 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <AvaloniaResource Include="Assets\**" />
+        <AvaloniaResource Include="Assets\**"/>
     </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="11.3.10" />
-        <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.3.0" />
+        <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.3.0"/>
         <PackageReference Include="Avalonia.Desktop" Version="11.3.10" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Include="Avalonia.Diagnostics" Version="11.3.10">
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
             <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="AvaloniaEdit.TextMate" Version="11.3.0" />
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+        <PackageReference Include="AvaloniaEdit.TextMate" Version="11.3.0"/>
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0"/>
         <PackageReference Include="HotAvalonia" Version="3.0.2" PrivateAssets="All" />
         <PackageReference Include="Jab" Version="0.12.0" PrivateAssets="All" />
-        <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4" />
-        <PackageReference Include="Serilog" Version="4.3.0" />
-        <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+        <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4"/>
+        <PackageReference Include="Serilog" Version="4.3.0"/>
+        <PackageReference Include="Serilog.Sinks.File" Version="7.0.0"/>
         <PackageReference Include="TextMateSharp.Grammars" Version="1.0.70" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\ShadUI\ShadUI.csproj" />
+        <ProjectReference Include="..\ShadUI\ShadUI.csproj"/>
     </ItemGroup>
 
     <ItemGroup>
@@ -54,17 +54,23 @@
 
     <Target Name="GenerateXamlTextCopies" BeforeTargets="PrepareForRun">
         <ItemGroup>
-            <XamlFiles Include="Views\**\*.axaml" />
+            <XamlFiles Include="Views\**\*.axaml"/>
         </ItemGroup>
 
-        <Copy SourceFiles="@(XamlFiles)" DestinationFiles="@(XamlFiles->'$(OutDir)views/%(RecursiveDir)%(Filename).axaml')" SkipUnchangedFiles="true" />
+        <Copy SourceFiles="@(XamlFiles)" 
+              
+              DestinationFiles="@(XamlFiles->'$(OutDir)views/%(RecursiveDir)%(Filename).axaml')" 
+              SkipUnchangedFiles="true"/>
     </Target>
 
     <Target Name="GenerateCSharpTextCopies" BeforeTargets="PrepareForRun">
         <ItemGroup>
-            <CSharpFiles Include="ViewModels\**\*.cs" Exclude="ViewModels\ViewModelBase.cs" />
+            <CSharpFiles Include="ViewModels\**\*.cs" Exclude="ViewModels\ViewModelBase.cs"/>
         </ItemGroup>
 
-        <Copy SourceFiles="@(CSharpFiles)" DestinationFiles="@(CSharpFiles->'$(OutDir)viewModels/%(RecursiveDir)%(Filename).cs')" SkipUnchangedFiles="true" />
+        <Copy SourceFiles="@(CSharpFiles)" 
+              
+              DestinationFiles="@(CSharpFiles->'$(OutDir)viewModels/%(RecursiveDir)%(Filename).cs')" 
+              SkipUnchangedFiles="true"/>
     </Target>
 </Project>

--- a/src/ShadUI.Demo/ShadUI.Demo.csproj
+++ b/src/ShadUI.Demo/ShadUI.Demo.csproj
@@ -19,30 +19,30 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <AvaloniaResource Include="Assets\**"/>
+        <AvaloniaResource Include="Assets\**" />
     </ItemGroup>
 
     <ItemGroup>
         <PackageReference Include="Avalonia" Version="11.3.10" />
-        <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.3.0"/>
+        <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.3.0" />
         <PackageReference Include="Avalonia.Desktop" Version="11.3.10" />
         <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
         <PackageReference Include="Avalonia.Diagnostics" Version="11.3.10">
             <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
             <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="AvaloniaEdit.TextMate" Version="11.3.0"/>
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0"/>
+        <PackageReference Include="AvaloniaEdit.TextMate" Version="11.3.0" />
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageReference Include="HotAvalonia" Version="3.0.2" PrivateAssets="All" />
         <PackageReference Include="Jab" Version="0.12.0" PrivateAssets="All" />
-        <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4"/>
-        <PackageReference Include="Serilog" Version="4.3.0"/>
-        <PackageReference Include="Serilog.Sinks.File" Version="7.0.0"/>
+        <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4" />
+        <PackageReference Include="Serilog" Version="4.3.0" />
+        <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
         <PackageReference Include="TextMateSharp.Grammars" Version="1.0.70" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\ShadUI\ShadUI.csproj"/>
+        <ProjectReference Include="..\ShadUI\ShadUI.csproj" />
     </ItemGroup>
 
     <ItemGroup>
@@ -54,21 +54,17 @@
 
     <Target Name="GenerateXamlTextCopies" BeforeTargets="PrepareForRun">
         <ItemGroup>
-            <XamlFiles Include="Views\**\*.axaml"/>
+            <XamlFiles Include="Views\**\*.axaml" />
         </ItemGroup>
 
-        <Copy SourceFiles="@(XamlFiles)"
-              DestinationFiles="@(XamlFiles->'$(OutDir)views/%(RecursiveDir)%(Filename).axaml')"
-              SkipUnchangedFiles="true"/>
+        <Copy SourceFiles="@(XamlFiles)" DestinationFiles="@(XamlFiles->'$(OutDir)views/%(RecursiveDir)%(Filename).axaml')" SkipUnchangedFiles="true" />
     </Target>
 
     <Target Name="GenerateCSharpTextCopies" BeforeTargets="PrepareForRun">
         <ItemGroup>
-            <CSharpFiles Include="ViewModels\**\*.cs" Exclude="ViewModels\ViewModelBase.cs"/>
+            <CSharpFiles Include="ViewModels\**\*.cs" Exclude="ViewModels\ViewModelBase.cs" />
         </ItemGroup>
 
-        <Copy SourceFiles="@(CSharpFiles)"
-              DestinationFiles="@(CSharpFiles->'$(OutDir)viewModels/%(RecursiveDir)%(Filename).cs')"
-              SkipUnchangedFiles="true"/>
+        <Copy SourceFiles="@(CSharpFiles)" DestinationFiles="@(CSharpFiles->'$(OutDir)viewModels/%(RecursiveDir)%(Filename).cs')" SkipUnchangedFiles="true" />
     </Target>
 </Project>

--- a/src/ShadUI.Demo/ViewModels/AvatarViewModel.cs
+++ b/src/ShadUI.Demo/ViewModels/AvatarViewModel.cs
@@ -20,7 +20,7 @@ public sealed partial class AvatarViewModel : ViewModelBase, INavigable
     [RelayCommand]
     private void BackPage()
     {
-        _pageManager.Navigate<TypographyViewModel>();
+        _pageManager.Navigate<SmoothScrollViewModel>();
     }
 
     [RelayCommand]

--- a/src/ShadUI.Demo/ViewModels/Examples/DataTable/BasicDataTableViewModel.cs
+++ b/src/ShadUI.Demo/ViewModels/Examples/DataTable/BasicDataTableViewModel.cs
@@ -21,7 +21,38 @@ public sealed partial class BasicDataTableViewModel : ViewModelBase
         new() { Status = Status.Processing, Email = "monserrat44@example.com", Amount = 837 },
         new() { Status = Status.Success, Email = "silas22@example.com", Amount = 874 },
         new() { Status = Status.Failed, Email = "carmella@example.com", Amount = 721 },
-        new() { Status = Status.Success, Email = "ken99@example.com", Amount = 316 }
+        new() { Status = Status.Success, Email = "ken99@example.com", Amount = 316 },
+        new() { Status = Status.Processing, Email = "alice.johnson@example.com", Amount = 542 },
+        new() { Status = Status.Failed, Email = "bob.smith@example.com", Amount = 189 },
+        new() { Status = Status.Success, Email = "charlie.brown@example.com", Amount = 736 },
+        new() { Status = Status.Processing, Email = "diana.prince@example.com", Amount = 423 },
+        new() { Status = Status.Success, Email = "ethan.hunt@example.com", Amount = 891 },
+        new() { Status = Status.Failed, Email = "fiona.apple@example.com", Amount = 267 },
+        new() { Status = Status.Success, Email = "george.washington@example.com", Amount = 654 },
+        new() { Status = Status.Processing, Email = "helen.keller@example.com", Amount = 338 },
+        new() { Status = Status.Failed, Email = "ivan.drago@example.com", Amount = 712 },
+        new() { Status = Status.Success, Email = "jane.doe@example.com", Amount = 495 },
+        new() { Status = Status.Processing, Email = "kevin.bacon@example.com", Amount = 823 },
+        new() { Status = Status.Success, Email = "laura.croft@example.com", Amount = 156 },
+        new() { Status = Status.Failed, Email = "mike.tyson@example.com", Amount = 674 },
+        new() { Status = Status.Processing, Email = "nancy.drew@example.com", Amount = 381 },
+        new() { Status = Status.Success, Email = "oscar.wilde@example.com", Amount = 529 },
+        new() { Status = Status.Failed, Email = "peter.parker@example.com", Amount = 745 },
+        new() { Status = Status.Success, Email = "quinn.reynolds@example.com", Amount = 298 },
+        new() { Status = Status.Processing, Email = "rachel.green@example.com", Amount = 612 },
+        new() { Status = Status.Failed, Email = "steve.jobs@example.com", Amount = 867 },
+        new() { Status = Status.Success, Email = "tina.turner@example.com", Amount = 433 },
+        new() { Status = Status.Processing, Email = "ulysses.grant@example.com", Amount = 756 },
+        new() { Status = Status.Failed, Email = "victoria.secret@example.com", Amount = 221 },
+        new() { Status = Status.Success, Email = "walter.white@example.com", Amount = 584 },
+        new() { Status = Status.Processing, Email = "xena.warrior@example.com", Amount = 349 },
+        new() { Status = Status.Failed, Email = "yoda.master@example.com", Amount = 793 },
+        new() { Status = Status.Success, Email = "zoe.saldana@example.com", Amount = 416 },
+        new() { Status = Status.Processing, Email = "adam.sandler@example.com", Amount = 678 },
+        new() { Status = Status.Failed, Email = "betty.white@example.com", Amount = 205 },
+        new() { Status = Status.Success, Email = "carl.sagan@example.com", Amount = 841 },
+        new() { Status = Status.Processing, Email = "debbie.harry@example.com", Amount = 362 },
+        new() { Status = Status.Failed, Email = "elvis.presley@example.com", Amount = 725 },
     ];
 
     private readonly Timer? _searchTimer;
@@ -46,11 +77,9 @@ public sealed partial class BasicDataTableViewModel : ViewModelBase
         Items = new ObservableCollection<DataGridItem>(_originalItems);
     }
 
-    [ObservableProperty]
-    private string _xamlCode = string.Empty;
+    [ObservableProperty] private string _xamlCode = string.Empty;
 
-    [ObservableProperty]
-    private string _cSharpCode = string.Empty;
+    [ObservableProperty] private string _cSharpCode = string.Empty;
 
     private void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
@@ -117,14 +146,11 @@ public sealed partial class BasicDataTableViewModel : ViewModelBase
         SelectedCount = Items.Count(item => item.IsSelected);
     }
 
-    [ObservableProperty]
-    private string _searchString = string.Empty;
+    [ObservableProperty] private string _searchString = string.Empty;
 
-    [ObservableProperty]
-    private bool _isSearching;
+    [ObservableProperty] private bool _isSearching;
 
-    [ObservableProperty]
-    private bool? _selectAll = false;
+    [ObservableProperty] private bool? _selectAll = false;
 
     [RelayCommand]
     private void ToggleSelection(bool? selectAll)
@@ -135,17 +161,13 @@ public sealed partial class BasicDataTableViewModel : ViewModelBase
         }
     }
 
-    [ObservableProperty]
-    private int _selectedCount;
+    [ObservableProperty] private int _selectedCount;
 
-    [ObservableProperty]
-    private int _totalCount;
+    [ObservableProperty] private int _totalCount;
 
-    [ObservableProperty]
-    private ObservableCollection<DataGridItem> _items;
+    [ObservableProperty] private ObservableCollection<DataGridItem> _items;
 
-    [ObservableProperty]
-    private bool _showStatusColumn = true;
+    [ObservableProperty] private bool _showStatusColumn = true;
 
     [RelayCommand]
     private void ToggleStatusColumn()
@@ -153,8 +175,7 @@ public sealed partial class BasicDataTableViewModel : ViewModelBase
         ShowStatusColumn = !ShowStatusColumn;
     }
 
-    [ObservableProperty]
-    private bool _showEmailColumn = true;
+    [ObservableProperty] private bool _showEmailColumn = true;
 
     [RelayCommand]
     private void ToggleEmailColumn()
@@ -162,8 +183,7 @@ public sealed partial class BasicDataTableViewModel : ViewModelBase
         ShowEmailColumn = !ShowEmailColumn;
     }
 
-    [ObservableProperty]
-    private bool _showAmountColumn = true;
+    [ObservableProperty] private bool _showAmountColumn = true;
 
     [RelayCommand]
     private void ToggleAmountColumn()
@@ -191,11 +211,9 @@ public sealed partial class BasicDataTableViewModel : ViewModelBase
 
 public sealed partial class DataGridItem : ObservableValidator
 {
-    [ObservableProperty]
-    private bool _isSelected;
+    [ObservableProperty] private bool _isSelected;
 
-    [ObservableProperty]
-    private Status _status;
+    [ObservableProperty] private Status _status;
 
     private string _email = string.Empty;
 
@@ -206,18 +224,14 @@ public sealed partial class DataGridItem : ObservableValidator
         set => SetProperty(ref _email, value, true);
     }
 
-    [ObservableProperty]
-    private decimal _amount;
+    [ObservableProperty] private decimal _amount;
 }
 
 public enum Status
 {
-    [Display(Name = "Success")]
-    Success,
+    [Display(Name = "Success")] Success,
 
-    [Display(Name = "Processing")]
-    Processing,
+    [Display(Name = "Processing")] Processing,
 
-    [Display(Name = "Failed")]
-    Failed
+    [Display(Name = "Failed")] Failed
 }

--- a/src/ShadUI.Demo/ViewModels/Examples/DataTable/BasicDataTableViewModel.cs
+++ b/src/ShadUI.Demo/ViewModels/Examples/DataTable/BasicDataTableViewModel.cs
@@ -170,6 +170,23 @@ public sealed partial class BasicDataTableViewModel : ViewModelBase
     {
         ShowAmountColumn = !ShowAmountColumn;
     }
+
+    public override void Dispose()
+    {
+        if (_searchTimer != null)
+        {
+            _searchTimer.Stop();
+            _searchTimer.Elapsed -= SearchTimerElapsed;
+            _searchTimer.Dispose();
+        }
+
+        PropertyChanged -= OnPropertyChanged;
+
+        foreach (var item in _originalItems)
+            item.PropertyChanged -= OnItemsChanged;
+
+        base.Dispose();
+    }
 }
 
 public sealed partial class DataGridItem : ObservableValidator

--- a/src/ShadUI.Demo/ViewModels/Examples/Typography/TextBlockViewModel.cs
+++ b/src/ShadUI.Demo/ViewModels/Examples/Typography/TextBlockViewModel.cs
@@ -20,6 +20,7 @@ public sealed partial class TextBlockViewModel : ViewModelBase
         CaptionCode = path.ExtractByLineRange(66, 69).CleanIndentation();
         MutedCode = path.ExtractByLineRange(72, 75).CleanIndentation();
         ErrorCode = path.ExtractByLineRange(78, 81).CleanIndentation();
+        MarqueeCode = path.ExtractByLineRange(85, 90).CleanIndentation();
     }
 
     [ObservableProperty]
@@ -54,4 +55,7 @@ public sealed partial class TextBlockViewModel : ViewModelBase
 
     [ObservableProperty]
     private string _errorCode = string.Empty;
+
+    [ObservableProperty]
+    private string _marqueeCode = string.Empty;
 }

--- a/src/ShadUI.Demo/ViewModels/InputViewModel.cs
+++ b/src/ShadUI.Demo/ViewModels/InputViewModel.cs
@@ -110,4 +110,16 @@ public sealed partial class InputViewModel : ViewModelBase, INavigable
     {
         InputForm.Initialize();
     }
+
+    public override void Dispose()
+    {
+        if (_searchTimer != null)
+        {
+            _searchTimer.Stop();
+            _searchTimer.Elapsed -= SearchTimerElapsed;
+            _searchTimer.Dispose();
+        }
+
+        base.Dispose();
+    }
 }

--- a/src/ShadUI.Demo/ViewModels/SmoothScrollViewModel.cs
+++ b/src/ShadUI.Demo/ViewModels/SmoothScrollViewModel.cs
@@ -16,9 +16,9 @@ public sealed partial class SmoothScrollViewModel : ViewModelBase, INavigable
     {
         _pageManager = pageManager;
         var path = Path.Combine(AppContext.BaseDirectory, "views", "SmoothScrollPage.axaml");
-        UsageCode = path.ExtractByLineRange(86, 114).CleanIndentation();
+        UsageCode = path.ExtractByLineRange(86, 115).CleanIndentation();
         
-        for (int i = 1; i <= 300; i++)
+        for (int i = 1; i <= 324; i++)
         {
             ScrollItems.Add($"#{i}");
         }

--- a/src/ShadUI.Demo/ViewModels/SmoothScrollViewModel.cs
+++ b/src/ShadUI.Demo/ViewModels/SmoothScrollViewModel.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.IO;
+using Avalonia.Controls;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace ShadUI.Demo.ViewModels;
+
+[Page("smoothScroll")]
+public sealed partial class SmoothScrollViewModel : ViewModelBase, INavigable
+{
+    private readonly PageManager _pageManager;
+
+    public SmoothScrollViewModel(PageManager pageManager)
+    {
+        _pageManager = pageManager;
+        var path = Path.Combine(AppContext.BaseDirectory, "views", "SmoothScrollPage.axaml");
+        UsageCode = path.ExtractByLineRange(86, 114).CleanIndentation();
+        
+        for (int i = 1; i <= 300; i++)
+        {
+            ScrollItems.Add($"#{i}");
+        }
+    }
+
+    [RelayCommand]
+    private void BackPage()
+    {
+        _pageManager.Navigate<TypographyViewModel>();
+    }
+
+    [RelayCommand]
+    private void NextPage()
+    {
+        _pageManager.Navigate<AvatarViewModel>();
+    }
+
+    [ObservableProperty]
+    private string _usageCode = string.Empty;
+    
+    
+    public ObservableCollection<string> ScrollItems { get; } = [];
+
+    [ObservableProperty]
+    private bool _isEnabled = true;
+
+    [ObservableProperty]
+    private double _baseStepSize = SmoothScrollAssist.BaseStepSizeProperty.GetDefaultValue(typeof(ScrollViewer));
+
+    [ObservableProperty]
+    private double _smoothingFactor = SmoothScrollAssist.SmoothingFactorProperty.GetDefaultValue(typeof(ScrollViewer));
+}

--- a/src/ShadUI.Demo/ViewModels/SmoothScrollViewModel.cs
+++ b/src/ShadUI.Demo/ViewModels/SmoothScrollViewModel.cs
@@ -46,8 +46,8 @@ public sealed partial class SmoothScrollViewModel : ViewModelBase, INavigable
     private bool _isEnabled = true;
 
     [ObservableProperty]
-    private double _baseStepSize = SmoothScrollAssist.BaseStepSizeProperty.GetDefaultValue(typeof(ScrollViewer));
+    private double? _baseStepSize = SmoothScrollAssist.BaseStepSizeProperty.GetDefaultValue(typeof(ScrollViewer));
 
     [ObservableProperty]
-    private double _smoothingFactor = SmoothScrollAssist.SmoothingFactorProperty.GetDefaultValue(typeof(ScrollViewer));
+    private double? _smoothingFactor = SmoothScrollAssist.SmoothingFactorProperty.GetDefaultValue(typeof(ScrollViewer));
 }

--- a/src/ShadUI.Demo/ViewModels/TypographyViewModel.cs
+++ b/src/ShadUI.Demo/ViewModels/TypographyViewModel.cs
@@ -67,7 +67,7 @@ public sealed partial class TypographyViewModel : ViewModelBase, INavigable
     [RelayCommand]
     private void NextPage()
     {
-        _pageManager.Navigate<AvatarViewModel>();
+        _pageManager.Navigate<SmoothScrollViewModel>();
     }
 
     [ObservableProperty]

--- a/src/ShadUI.Demo/Views/Examples/DataTable/BasicDataTableContent.axaml
+++ b/src/ShadUI.Demo/Views/Examples/DataTable/BasicDataTableContent.axaml
@@ -74,6 +74,7 @@
                 GridLinesVisibility="Horizontal"
                 ItemsSource="{Binding Items}"
                 SelectionMode="Single"
+                Height="300"
                 x:Name="DataGrid">
                 <DataGrid.Columns>
                     <DataGridCheckBoxColumn Binding="{Binding IsSelected}" CanUserSort="False">

--- a/src/ShadUI.Demo/Views/Examples/Typography/TextBlockContent.axaml
+++ b/src/ShadUI.Demo/Views/Examples/Typography/TextBlockContent.axaml
@@ -82,9 +82,11 @@
                 TextWrapping="Wrap" />
         </controls:ControlBlock>
 
-        <controls:ControlBlock Title="Marquee" Xaml="{Binding}">
-            <shadui:MarqueeTextBlock TextValue="testtesttesttest"
-                                     MinHeight="30"/>
+        <controls:ControlBlock Title="Marquee" Xaml="{Binding MarqueeCode}">
+            <shadui:MarqueeTextBlock 
+                TextValue="ShadUI ShadUI ShadUI ShadUI ShadUI"
+                Width="150" 
+                HorizontalAlignment="Left"/>
         </controls:ControlBlock>
     </StackPanel>
 </UserControl>

--- a/src/ShadUI.Demo/Views/Examples/Typography/TextBlockContent.axaml
+++ b/src/ShadUI.Demo/Views/Examples/Typography/TextBlockContent.axaml
@@ -1,5 +1,5 @@
 ﻿<UserControl
-    d:DesignHeight="3850"
+    d:DesignHeight="450"
     d:DesignWidth="800"
     mc:Ignorable="d"
     x:Class="ShadUI.Demo.Views.Examples.Typography.TextBlockContent"

--- a/src/ShadUI.Demo/Views/Examples/Typography/TextBlockContent.axaml
+++ b/src/ShadUI.Demo/Views/Examples/Typography/TextBlockContent.axaml
@@ -85,7 +85,7 @@
         <controls:ControlBlock Title="Marquee" Xaml="{Binding MarqueeCode}">
             <shadui:MarqueeTextBlock 
                 TextValue="ShadUI ShadUI ShadUI ShadUI ShadUI"
-                Width="100" 
+                Width="100" Classes="Small"
                 HorizontalAlignment="Left"/>
         </controls:ControlBlock>
     </StackPanel>

--- a/src/ShadUI.Demo/Views/Examples/Typography/TextBlockContent.axaml
+++ b/src/ShadUI.Demo/Views/Examples/Typography/TextBlockContent.axaml
@@ -1,5 +1,5 @@
 ﻿<UserControl
-    d:DesignHeight="450"
+    d:DesignHeight="3850"
     d:DesignWidth="800"
     mc:Ignorable="d"
     x:Class="ShadUI.Demo.Views.Examples.Typography.TextBlockContent"
@@ -9,6 +9,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:typography="clr-namespace:ShadUI.Demo.ViewModels.Examples.Typography"
+    xmlns:shadui="clr-namespace:ShadUI;assembly=ShadUI"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <StackPanel
         Margin="{StaticResource PageMargin}"
@@ -79,6 +80,11 @@
                 Classes="Caption Error"
                 Text="Invalid email address"
                 TextWrapping="Wrap" />
+        </controls:ControlBlock>
+
+        <controls:ControlBlock Title="Marquee" Xaml="{Binding}">
+            <shadui:MarqueeTextBlock TextValue="testtesttesttest"
+                                     MinHeight="30"/>
         </controls:ControlBlock>
     </StackPanel>
 </UserControl>

--- a/src/ShadUI.Demo/Views/Examples/Typography/TextBlockContent.axaml
+++ b/src/ShadUI.Demo/Views/Examples/Typography/TextBlockContent.axaml
@@ -85,7 +85,7 @@
         <controls:ControlBlock Title="Marquee" Xaml="{Binding MarqueeCode}">
             <shadui:MarqueeTextBlock 
                 TextValue="ShadUI ShadUI ShadUI ShadUI ShadUI"
-                Width="150" 
+                Width="100" 
                 HorizontalAlignment="Left"/>
         </controls:ControlBlock>
     </StackPanel>

--- a/src/ShadUI.Demo/Views/SmoothScrollPage.axaml
+++ b/src/ShadUI.Demo/Views/SmoothScrollPage.axaml
@@ -97,14 +97,15 @@
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
                                 <Border
-                                    Background="Black"
+                                    Background="{DynamicResource PrimaryColor}"
+                                    CornerRadius="{DynamicResource LgCornerRadius}"
                                     Width="100"
                                     Height="100"
-                                    Margin="12">
+                                    Margin="8">
                                     <TextBlock
                                         HorizontalAlignment="Center"
                                         VerticalAlignment="Center"
-                                        Foreground="White"
+                                        Foreground="{DynamicResource PrimaryForegroundColor}"
                                         Text="{Binding}"
                                         Classes="h4"  />
                                 </Border>

--- a/src/ShadUI.Demo/Views/SmoothScrollPage.axaml
+++ b/src/ShadUI.Demo/Views/SmoothScrollPage.axaml
@@ -1,0 +1,118 @@
+﻿<UserControl
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    mc:Ignorable="d"
+    x:Class="ShadUI.Demo.Views.SmoothScrollPage"
+    x:DataType="viewModels:SmoothScrollViewModel"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:controls="clr-namespace:ShadUI.Demo.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:shadui="clr-namespace:ShadUI;assembly=ShadUI"
+    xmlns:viewModels="clr-namespace:ShadUI.Demo.ViewModels"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <DockPanel LastChildFill="True">
+        <StackPanel
+            DockPanel.Dock="Top"
+            Margin="{StaticResource PageMargin}"
+            MaxWidth="{StaticResource PageMaxWidth}"
+            Spacing="4">
+            <Grid ColumnDefinitions="* Auto">
+                <TextBlock Classes="h2" Text="Smooth Scroll" />
+                <StackPanel
+                    Grid.Column="1"
+                    Orientation="Horizontal"
+                    Spacing="8">
+                    <Button
+                        Background="{DynamicResource GhostHoverColor}"
+                        Classes="Icon"
+                        Command="{Binding BackPageCommand}"
+                        Height="28"
+                        Width="28">
+                        <Viewbox Margin="6">
+                            <TextBlock Classes="LucideIcon" Text="&#57420;" />
+                        </Viewbox>
+                    </Button>
+                    <Button
+                        Background="{DynamicResource GhostHoverColor}"
+                        Classes="Icon"
+                        Command="{Binding NextPageCommand}"
+                        Height="28"
+                        Width="28">
+                        <Viewbox Margin="6">
+                            <TextBlock Classes="LucideIcon" Text="&#57421;" />
+                        </Viewbox>
+                    </Button>
+                </StackPanel>
+            </Grid>
+            <TextBlock
+                Classes="p"
+                Text="Adds smooth scrolling to ScrollViewers with a customizable step size and smoothing factor."
+                TextWrapping="Wrap" />
+            <StackPanel
+                Spacing="12"
+                Orientation="Horizontal"
+                Margin="0,16,0,0">
+                <Grid RowDefinitions="Auto, *">
+                    <Label
+                        Margin="0,-3, 0, 3"
+                        Content="Is Enabled"
+                        FontSize="14" 
+                        FontWeight="Medium"/>
+                    <ToggleButton
+                        Grid.Row="1"
+                        Classes="Outline"
+                        Padding="8"
+                        IsChecked="{Binding IsEnabled}">
+                        <TextBlock Classes="LucideIcon" Text="&#57456;"/>
+                    </ToggleButton>
+                </Grid>
+                <NumericUpDown
+                    Value="{Binding BaseStepSize}"
+                    Width="155"
+                    shadui:ControlAssist.Label="Base Step Size" />
+                <NumericUpDown
+                    Value="{Binding SmoothingFactor}"
+                    Width="155"
+                    shadui:ControlAssist.Label="Smoothing Factor" />
+            </StackPanel>
+        </StackPanel>
+        
+        <ScrollViewer>
+            <controls:ControlBlock
+                Xaml="{Binding UsageCode}"
+                Margin="{StaticResource PageMargin}"
+                MaxWidth="{StaticResource PageMaxWidth}">
+                <ScrollViewer HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Auto"
+                    shadui:SmoothScrollAssist.IsEnabled="{Binding IsEnabled}"
+                    shadui:SmoothScrollAssist.BaseStepSize="{Binding BaseStepSize}"
+                    shadui:SmoothScrollAssist.SmoothingFactor="{Binding SmoothingFactor}"
+                    Height="315">
+                    <ItemsControl ItemsSource="{Binding ScrollItems}">
+                        <ItemsControl.ItemsPanel>
+                            <ItemsPanelTemplate>
+                                <WrapPanel Orientation="Horizontal" Width="3200"  />
+                            </ItemsPanelTemplate>
+                        </ItemsControl.ItemsPanel>
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <Border
+                                    Background="Black"
+                                    Width="100"
+                                    Height="100"
+                                    Margin="12">
+                                    <TextBlock
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Foreground="White"
+                                        Text="{Binding}"
+                                        Classes="h4"  />
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                </ScrollViewer>
+            </controls:ControlBlock>
+        </ScrollViewer>
+    </DockPanel>
+</UserControl>

--- a/src/ShadUI.Demo/Views/SmoothScrollPage.axaml.cs
+++ b/src/ShadUI.Demo/Views/SmoothScrollPage.axaml.cs
@@ -1,0 +1,11 @@
+﻿using Avalonia.Controls;
+
+namespace ShadUI.Demo.Views;
+
+public partial class SmoothScrollPage : UserControl
+{
+    public SmoothScrollPage()
+    {
+        InitializeComponent();
+    }
+}

--- a/src/ShadUI/AttachedProperties/NumericUpDownAssist.cs
+++ b/src/ShadUI/AttachedProperties/NumericUpDownAssist.cs
@@ -1,0 +1,178 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+
+// ReSharper disable once CheckNamespace
+namespace ShadUI;
+
+/// <summary>
+///     Provides attached properties for enhancing NumericUpDown functionality.
+/// </summary>
+/// <remarks>
+///     The NumericUpDownAssist class offers attached properties that extend the functionality
+///     of NumericUpDown controls in Avalonia applications. It provides input restriction
+///     capabilities that prevent users from entering non-numeric characters.
+///     Example usage in XAML:
+///     <code>
+///     &lt;NumericUpDown shadui:NumericUpDownAssist.NumericOnly="True" /&gt;
+///     </code>
+/// </remarks>
+public class NumericUpDownAssist
+{
+    static NumericUpDownAssist()
+    {
+        NumericOnlyProperty.Changed.AddClassHandler<NumericUpDown>(HandleNumericOnlyChanged);
+    }
+
+    /// <summary>
+    ///     Gets or sets whether the NumericUpDown should only accept numeric input.
+    /// </summary>
+    /// <remarks>
+    ///     When set to true, this property prevents users from entering non-numeric characters.
+    ///     Allowed input includes digits 0-9, decimal point (.), minus sign (-) for negative numbers,
+    ///     navigation keys (arrows, home, end), editing keys (backspace, delete),
+    ///     and tab for focus navigation.
+    /// </remarks>
+    public static readonly AttachedProperty<bool> NumericOnlyProperty =
+        AvaloniaProperty.RegisterAttached<NumericUpDownAssist, NumericUpDown, bool>(
+            "NumericOnly", false);
+
+    /// <summary>
+    ///     Sets whether the NumericUpDown should only accept numeric input.
+    /// </summary>
+    /// <param name="element">The NumericUpDown element.</param>
+    /// <param name="value">True to restrict to numeric input; false to allow any input.</param>
+    public static void SetNumericOnly(NumericUpDown element, bool value)
+    {
+        element.SetValue(NumericOnlyProperty, value);
+    }
+
+    /// <summary>
+    ///     Gets whether the NumericUpDown is restricted to numeric input.
+    /// </summary>
+    /// <param name="element">The NumericUpDown element.</param>
+    /// <returns>True if restricted to numeric input; false otherwise.</returns>
+    public static bool GetNumericOnly(NumericUpDown element)
+    {
+        return element.GetValue(NumericOnlyProperty);
+    }
+
+    private static void HandleNumericOnlyChanged(NumericUpDown numericUpDown, AvaloniaPropertyChangedEventArgs args)
+    {
+        CleanupHandlers(numericUpDown);
+
+        if (args.NewValue is not true) return;
+
+        var textBox = numericUpDown.FindControl<TextBox>("PART_TextBox");
+
+        if (textBox == null)
+        {
+            void OnTemplateApplied(object? sender, TemplateAppliedEventArgs e)
+            {
+                numericUpDown.TemplateApplied -= OnTemplateApplied;
+
+                if (!GetNumericOnly(numericUpDown)) return;
+
+                if (e.NameScope.Find<TextBox>("PART_TextBox") is { } tb)
+                {
+                    SetupInputFiltering(numericUpDown, tb);
+                }
+            }
+
+            numericUpDown.TemplateApplied += OnTemplateApplied;
+        }
+        else
+        {
+            SetupInputFiltering(numericUpDown, textBox);
+        }
+    }
+
+    private static void SetupInputFiltering(NumericUpDown numericUpDown, TextBox textBox)
+    {
+        numericUpDown.SetValue(InputHandlersProperty, new InputHandlers
+        {
+            TextBox = textBox,
+            TextInputHandler = OnTextInput,
+            KeyDownHandler = OnKeyDown
+        });
+
+        textBox.AddHandler(InputElement.TextInputEvent, OnTextInput, RoutingStrategies.Tunnel);
+        textBox.KeyDown += OnKeyDown;
+        return;
+
+        void OnTextInput(object? sender, TextInputEventArgs e)
+        {
+            if (sender is not TextBox tb || string.IsNullOrEmpty(e.Text)) return;
+
+            foreach (var c in e.Text)
+            {
+                if (char.IsDigit(c)) continue;
+
+                var currentText = tb.Text ?? string.Empty;
+                var selectionStart = tb.SelectionStart;
+                var isAllSelected = tb.SelectionStart == 0 && tb.SelectionEnd == currentText.Length;
+
+                if (c == '-')
+                {
+                    // Allow minus only at position 0 and if there's no existing minus
+                    if (selectionStart == 0 && !currentText.StartsWith("-"))
+                        continue;
+
+                    // Also allow if the entire text is selected (replacing all)
+                    if (isAllSelected)
+                        continue;
+                }
+
+                if (c == '.')
+                {
+                    // Allow decimal point if there's no existing one
+                    if (!currentText.Contains("."))
+                        continue;
+
+                    // Also allow if the entire text is selected (replacing all)
+                    if (isAllSelected)
+                        continue;
+                }
+
+                e.Handled = true;
+                return;
+            }
+        }
+
+        void OnKeyDown(object? sender, KeyEventArgs e)
+        {
+            // Reserved for future key filtering if needed
+        }
+    }
+
+    private static void CleanupHandlers(NumericUpDown? numericUpDown)
+    {
+        var handlers = numericUpDown?.GetValue(InputHandlersProperty);
+
+        if (handlers is null) return;
+
+        if (handlers.TextBox is not null)
+        {
+            if (handlers.TextInputHandler is not null)
+                handlers.TextBox.RemoveHandler(InputElement.TextInputEvent, handlers.TextInputHandler);
+
+            if (handlers.KeyDownHandler is not null)
+                handlers.TextBox.KeyDown -= handlers.KeyDownHandler;
+        }
+
+        numericUpDown?.ClearValue(InputHandlersProperty);
+    }
+
+    private class InputHandlers
+    {
+        public TextBox? TextBox { get; set; }
+        public EventHandler<TextInputEventArgs>? TextInputHandler { get; set; }
+        public EventHandler<KeyEventArgs>? KeyDownHandler { get; set; }
+    }
+
+    private static readonly AttachedProperty<InputHandlers> InputHandlersProperty =
+        AvaloniaProperty.RegisterAttached<NumericUpDownAssist, NumericUpDown, InputHandlers>("InputHandlers");
+}

--- a/src/ShadUI/AttachedProperties/SmoothScrollAssist.cs
+++ b/src/ShadUI/AttachedProperties/SmoothScrollAssist.cs
@@ -15,8 +15,8 @@ namespace ShadUI;
 /// </summary>
 public class SmoothScrollAssist
 {
-	static readonly bool IsMacOs =  RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-	static readonly ConditionalWeakTable<ScrollViewer, SmoothScrollController> Controllers = new();
+	private static readonly bool IsMacOs =  RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+	private static readonly ConditionalWeakTable<ScrollViewer, SmoothScrollController> Controllers = new();
 	
 	static SmoothScrollAssist()
 	{
@@ -47,20 +47,20 @@ public class SmoothScrollAssist
 	/// <param name="value">The smooth scroll value to set.</param>
 	public static void SetIsEnabled(ScrollViewer scrollViewer, bool value) =>
 		scrollViewer.SetValue(IsEnabledProperty, value);
-	
-	static void IsEnabledChanged(ScrollViewer scrollViewer, AvaloniaPropertyChangedEventArgs e)
+
+	private static void IsEnabledChanged(ScrollViewer scrollViewer, AvaloniaPropertyChangedEventArgs e)
 	{
 		if (e.NewValue is true && !Controllers.TryGetValue(scrollViewer, out _))
 		{
 			scrollViewer.IsScrollInertiaEnabled = false;
 
-			double baseStepSize = GetBaseStepSize(scrollViewer);
-			double smoothingFactor = GetSmoothingFactor(scrollViewer);
+			var baseStepSize = GetBaseStepSize(scrollViewer);
+			var smoothingFactor = GetSmoothingFactor(scrollViewer);
 			SmoothScrollController controller = new(scrollViewer, baseStepSize, smoothingFactor);
 			
 			Controllers.Add(scrollViewer, controller);
 		}
-		else if (Controllers.TryGetValue(scrollViewer, out SmoothScrollController controller))
+		else if (Controllers.TryGetValue(scrollViewer, out var controller))
 		{
 			controller.Stop();
 			
@@ -88,10 +88,10 @@ public class SmoothScrollAssist
 	/// </summary>
 	public static void SetBaseStepSize(ScrollViewer scrollViewer, double value) =>
 		scrollViewer.SetValue(BaseStepSizeProperty, value);
-	
-	static void BaseStepSizeChanged(ScrollViewer scrollViewer, AvaloniaPropertyChangedEventArgs e)
+
+	private static void BaseStepSizeChanged(ScrollViewer scrollViewer, AvaloniaPropertyChangedEventArgs e)
 	{
-		if (e.NewValue is not double newValue || !Controllers.TryGetValue(scrollViewer, out SmoothScrollController controller))
+		if (e.NewValue is not double newValue || !Controllers.TryGetValue(scrollViewer, out var controller))
 			return;
 		
 		controller.BaseStepSize = newValue;
@@ -115,10 +115,10 @@ public class SmoothScrollAssist
 	/// </summary>
 	public static void SetSmoothingFactor(ScrollViewer scrollViewer, double value) =>
 		scrollViewer.SetValue(SmoothingFactorProperty, value);
-	
-	static void SmoothingFactorChanged(ScrollViewer scrollViewer, AvaloniaPropertyChangedEventArgs e)
+
+	private static void SmoothingFactorChanged(ScrollViewer scrollViewer, AvaloniaPropertyChangedEventArgs e)
 	{
-		if (e.NewValue is not double newValue || !Controllers.TryGetValue(scrollViewer, out SmoothScrollController controller))
+		if (e.NewValue is not double newValue || !Controllers.TryGetValue(scrollViewer, out var controller))
 			return;
 		
 		controller.SmoothingFactor = newValue;

--- a/src/ShadUI/AttachedProperties/SmoothScrollAssist.cs
+++ b/src/ShadUI/AttachedProperties/SmoothScrollAssist.cs
@@ -1,0 +1,126 @@
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using Avalonia.Controls;
+using Avalonia;
+
+// ReSharper disable once CheckNamespace
+namespace ShadUI;
+
+/// <summary>
+///     Provides attached properties for adding smooth scroll to ScrollViewers.
+///     <para>
+///         Usage: Set <see cref="IsEnabledProperty" /> to <c>true</c> on a
+///         ScrollViewer to enable smooth scroll.
+///     </para>
+/// </summary>
+public class SmoothScrollAssist
+{
+	static readonly bool IsMacOs =  RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+	static readonly ConditionalWeakTable<ScrollViewer, SmoothScrollController> Controllers = new();
+	
+	static SmoothScrollAssist()
+	{
+		IsEnabledProperty.Changed.AddClassHandler<ScrollViewer>(IsEnabledChanged);
+		BaseStepSizeProperty.Changed.AddClassHandler<ScrollViewer>(BaseStepSizeChanged);
+		SmoothingFactorProperty.Changed.AddClassHandler<ScrollViewer>(SmoothingFactorChanged);
+	}
+	
+	
+	/// <summary>
+	///     Gets or sets whether smooth scroll should be enabled.
+	/// </summary>
+	public static readonly AttachedProperty<bool> IsEnabledProperty =
+		AvaloniaProperty.RegisterAttached<ScrollViewer, bool>("IsEnabled", typeof(SmoothScrollAssist));
+
+	/// <summary>
+	///     Gets the value of <see cref="IsEnabledProperty" />
+	/// </summary>
+	/// <param name="scrollViewer">The ScrollViewer.</param>
+	/// <returns>The smooth scroll value.</returns>
+	public static bool GetIsEnabled(ScrollViewer scrollViewer) =>
+		scrollViewer.GetValue(IsEnabledProperty);
+
+	/// <summary>
+	///     Sets the value of <see cref="IsEnabledProperty" />
+	/// </summary>
+	/// <param name="scrollViewer">The ScrollViewer.</param>
+	/// <param name="value">The smooth scroll value to set.</param>
+	public static void SetIsEnabled(ScrollViewer scrollViewer, bool value) =>
+		scrollViewer.SetValue(IsEnabledProperty, value);
+	
+	static void IsEnabledChanged(ScrollViewer scrollViewer, AvaloniaPropertyChangedEventArgs e)
+	{
+		if (e.NewValue is true && !Controllers.TryGetValue(scrollViewer, out _))
+		{
+			scrollViewer.IsScrollInertiaEnabled = false;
+
+			double baseStepSize = GetBaseStepSize(scrollViewer);
+			double smoothingFactor = GetSmoothingFactor(scrollViewer);
+			SmoothScrollController controller = new(scrollViewer, baseStepSize, smoothingFactor);
+			
+			Controllers.Add(scrollViewer, controller);
+		}
+		else if (Controllers.TryGetValue(scrollViewer, out SmoothScrollController controller))
+		{
+			controller.Stop();
+			
+			Controllers.Remove(scrollViewer);
+			
+			scrollViewer.IsScrollInertiaEnabled = true;
+		}
+	}
+	
+	
+	/// <summary>
+	///     Gets or sets the multiplier for each notch of the scroll wheel.
+	/// </summary>
+	public static readonly AttachedProperty<double> BaseStepSizeProperty =
+		AvaloniaProperty.RegisterAttached<ScrollViewer, double>("BaseStepSize", typeof(SmoothScrollAssist), IsMacOs ? 40 : 70);
+	
+	/// <summary>
+	///     Gets the value of <see cref="BaseStepSizeProperty" />
+	/// </summary>
+	public static double GetBaseStepSize(ScrollViewer scrollViewer) =>
+		scrollViewer.GetValue(BaseStepSizeProperty);
+
+	/// <summary>
+	///     Sets the value of <see cref="BaseStepSizeProperty" />
+	/// </summary>
+	public static void SetBaseStepSize(ScrollViewer scrollViewer, double value) =>
+		scrollViewer.SetValue(BaseStepSizeProperty, value);
+	
+	static void BaseStepSizeChanged(ScrollViewer scrollViewer, AvaloniaPropertyChangedEventArgs e)
+	{
+		if (e.NewValue is not double newValue || !Controllers.TryGetValue(scrollViewer, out SmoothScrollController controller))
+			return;
+		
+		controller.BaseStepSize = newValue;
+	}
+	
+	
+	/// <summary>
+	///     Gets or sets the smoothing intensity. Higher values feel "snappier", lower values feel "floatier".
+	/// </summary>
+	public static readonly AttachedProperty<double> SmoothingFactorProperty =
+		AvaloniaProperty.RegisterAttached<ScrollViewer, double>("SmoothingFactor", typeof(SmoothScrollAssist), IsMacOs ? 50 : 20);
+	
+	/// <summary>
+	///     Gets the value of <see cref="SmoothingFactorProperty" />
+	/// </summary>
+	public static double GetSmoothingFactor(ScrollViewer scrollViewer) =>
+		scrollViewer.GetValue(SmoothingFactorProperty);
+
+	/// <summary>
+	///     Sets the value of <see cref="SmoothingFactorProperty" />
+	/// </summary>
+	public static void SetSmoothingFactor(ScrollViewer scrollViewer, double value) =>
+		scrollViewer.SetValue(SmoothingFactorProperty, value);
+	
+	static void SmoothingFactorChanged(ScrollViewer scrollViewer, AvaloniaPropertyChangedEventArgs e)
+	{
+		if (e.NewValue is not double newValue || !Controllers.TryGetValue(scrollViewer, out SmoothScrollController controller))
+			return;
+		
+		controller.SmoothingFactor = newValue;
+	}
+}

--- a/src/ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.axaml
+++ b/src/ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.axaml
@@ -6,7 +6,6 @@
                   TargetType="shadui:MarqueeTextBlock">
         <Setter Property="Template">
             <ControlTemplate TargetType="shadui:MarqueeTextBlock">
-                <!-- ClipToBounds здесь — единственный механизм обрезки -->
                 <Border ClipToBounds="True"
                         HorizontalAlignment="Stretch"
                         VerticalAlignment="Stretch">
@@ -19,5 +18,4 @@
             </ControlTemplate>
         </Setter>
     </ControlTheme>
-
 </ResourceDictionary>

--- a/src/ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.axaml
+++ b/src/ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.axaml
@@ -1,0 +1,18 @@
+<ResourceDictionary xmlns="https://github.com/avaloniaui"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:shadui="clr-namespace:ShadUI">
+
+    <ControlTheme x:Key="typeof(shadui:MarqueeTextBlock)"
+                  TargetType="shadui:MarqueeTextBlock">
+        <Setter Property="Template">
+            <ControlTemplate TargetType="shadui:MarqueeTextBlock">
+                <Border ClipToBounds="True">
+                    <Canvas x:Name="PART_Canvas">
+                        <TextBlock x:Name="PART_Text"/>
+                    </Canvas>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+    </ControlTheme>
+
+</ResourceDictionary>

--- a/src/ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.axaml
+++ b/src/ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.axaml
@@ -2,13 +2,18 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:shadui="clr-namespace:ShadUI">
 
-    <ControlTheme x:Key="typeof(shadui:MarqueeTextBlock)"
+    <ControlTheme x:Key="{x:Type shadui:MarqueeTextBlock}"
                   TargetType="shadui:MarqueeTextBlock">
         <Setter Property="Template">
             <ControlTemplate TargetType="shadui:MarqueeTextBlock">
-                <Border ClipToBounds="True">
-                    <Canvas x:Name="PART_Canvas">
-                        <TextBlock x:Name="PART_Text"/>
+                <!-- ClipToBounds здесь — единственный механизм обрезки -->
+                <Border ClipToBounds="True"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch">
+                    <Canvas x:Name="PART_Canvas"
+                            HorizontalAlignment="Stretch"
+                            VerticalAlignment="Stretch">
+                        <TextBlock x:Name="PART_Text" />
                     </Canvas>
                 </Border>
             </ControlTemplate>

--- a/src/ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.cs
+++ b/src/ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.cs
@@ -37,7 +37,7 @@ public class MarqueeTextBlock : TemplatedControl
     /// Scrolling speed in pixels per second
     /// Duration is derived from this so speed stays constant regardless of text length
     /// </summary>
-    private const double ScrollSpeedPxPerSecond = 80.0;
+    private const double ScrollSpeedPxPerSecond = 100.0;
 
     private TextBlock? _textBlock;
     private Canvas? _canvas;

--- a/src/ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.cs
+++ b/src/ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.cs
@@ -12,7 +12,7 @@ using Avalonia.Styling;
 namespace ShadUI
 {
     /// <summary>
-    /// A templated control that scrolls its text horizontally when the content
+    /// Templated control that scrolls its text horizontally when the content
     /// width exceeds the available bounds (marquee / ticker effect).
     /// Requires PART_Canvas and PART_Text named parts in its control template.
     /// </summary>
@@ -22,7 +22,7 @@ namespace ShadUI
         /// Defines the <see cref="TextValue"/> styled property
         /// </summary>
         public static readonly StyledProperty<string> TextValueProperty =
-            AvaloniaProperty.Register<MarqueeTextBlock, string>(nameof(TextValue));
+            AvaloniaProperty.Register<MarqueeTextBlock, string>(nameof(TextValue), defaultValue: string.Empty);
 
         /// <summary>
         /// Gets or sets the text content displayed by this control
@@ -33,10 +33,16 @@ namespace ShadUI
             set => SetValue(TextValueProperty, value);
         }
 
+        /// <summary>
+        /// Scrolling speed in pixels per second.
+        /// Duration is derived from this value so speed stays constant for any text length.
+        /// </summary>
+        private const double ScrollSpeedPxPerSecond = 80.0;
+
         private TextBlock? _textBlock;
         private Canvas? _canvas;
 
-        private Action? _requestMarqueeStart;
+
         private EventHandler<VisualTreeAttachmentEventArgs>? _attachedHandler;
         private EventHandler<SizeChangedEventArgs>? _sizeChangedHandler;
         private NotifyCollectionChangedEventHandler? _classesChangedHandler;
@@ -51,13 +57,18 @@ namespace ShadUI
         /// </summary>
         private CancellationTokenSource? _animationCts;
 
+
         /// <summary>
         /// Resolves PART_Canvas and PART_Text, mirrors CSS classes, and wires up
-        /// all subscriptions that trigger marquee re-evaluation
+        /// all subscriptions that trigger marquee re-evaluation.
+        /// Called on first apply and again on theme changes — old handlers are
+        /// always unsubscribed first to prevent duplicate firings and memory leaks.
         /// </summary>
         protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
         {
             base.OnApplyTemplate(e);
+
+            DetachEventHandlers();
 
             _textBlock = e.NameScope.Find<TextBlock>("PART_Text");
             _canvas = e.NameScope.Find<Canvas>("PART_Canvas");
@@ -65,27 +76,43 @@ namespace ShadUI
             UpdateTextBlock();
             UpdateClasses();
 
-            _requestMarqueeStart = RequestMarqueeStart;
-
             _classesChangedHandler = (_, _) => UpdateClasses();
-            if (Classes is INotifyCollectionChanged incc)
-                incc.CollectionChanged += _classesChangedHandler;
+            _attachedHandler = (_, _) => RequestMarqueeStart();
+            _sizeChangedHandler = (_, _) => RequestMarqueeStart();
 
-            _attachedHandler = (_, _) => _requestMarqueeStart();
-            _sizeChangedHandler = (_, _) => _requestMarqueeStart();
-            this.AttachedToVisualTree += _attachedHandler;
-            this.SizeChanged += _sizeChangedHandler;
+            ((INotifyCollectionChanged)Classes).CollectionChanged += _classesChangedHandler;
 
-            _requestMarqueeStart();
+            AttachedToVisualTree += _attachedHandler;
+            SizeChanged += _sizeChangedHandler;
+
+            RequestMarqueeStart();
+        }
+
+        /// <summary>
+        /// Reports the TextBlock's natural height as the control's desired height.
+        /// Canvas always returns DesiredSize = (0, 0), so without this override the
+        /// control collapses and becomes invisible unless MinHeight is set explicitly.
+        /// <para>
+        /// After <c>base.MeasureOverride</c>, Canvas has already measured the TextBlock
+        /// with infinite space — no additional Measure call is needed.
+        /// </para>
+        /// </summary>
+        protected override Size MeasureOverride(Size availableSize)
+        {
+            var baseSize = base.MeasureOverride(availableSize);
+
+            if (_textBlock is null) 
+                return baseSize;
+
+            return new Size(baseSize.Width, _textBlock.DesiredSize.Height);
         }
 
 
-        /// <summary>
-        /// Pushes the current <see cref="TextValue"/> into the inner TextBlock
-        /// </summary>
+        /// <summary>Pushes the current <see cref="TextValue"/> into the inner TextBlock.</summary>
         private void UpdateTextBlock()
         {
-            if (_textBlock is null) return;
+            if (_textBlock is null) 
+                return;
             _textBlock.Text = TextValue;
         }
 
@@ -95,14 +122,14 @@ namespace ShadUI
         /// </summary>
         private void UpdateClasses()
         {
-            if (_textBlock is null) return;
+            if (_textBlock is null) 
+                return;
 
             _textBlock.Classes.Clear();
             foreach (var c in Classes)
                 if (!c.StartsWith(':'))
                     _textBlock.Classes.Add(c);
         }
-
 
         /// <summary>
         /// Cancels any pending debounce timer and schedules a fresh marquee start
@@ -117,72 +144,75 @@ namespace ShadUI
         }
 
         /// <summary>
-        /// Waits for the debounce delay then forwards to <see cref="StartMarquee"/>.
-        /// Exits silently if cancelled before the delay completes.
+        /// Waits for the debounce delay, disposes the completed CTS, then forwards
+        /// to <see cref="StartMarquee"/>. Exits silently if cancelled.
         /// </summary>
         private async void RunAfterDelay(CancellationToken debounceToken)
         {
             try
             {
                 await Task.Delay(150, debounceToken);
+
+                _debounceCts?.Dispose();
+                _debounceCts = null;
+
                 StartMarquee();
             }
             catch (OperationCanceledException) { }
         }
 
         /// <summary>
-        /// Cancels any running animation, then starts a new marquee loop when the
-        /// text is wider than the control. Resets the TextBlock position when not scrolling.
-        /// The TextBlock is vertically centred inside the Canvas at startup.
+        /// Starts a new marquee loop when the text is wider than the control,
+        /// or positions the text statically when it fits.
+        /// <para>
+        /// All guard checks run before the <see cref="CancellationTokenSource"/> is
+        /// allocated, so no CTS is ever created for a no-op call.
+        /// </para>
         /// </summary>
         private async void StartMarquee()
         {
-            if (_textBlock is null || _canvas is null) return;
+            if (_textBlock is null || _canvas is null) 
+                return;
+
+            if (Bounds.Width <= 0) 
+                return;
+
+            var textWidth = _textBlock.DesiredSize.Width;
+            if (textWidth <= 0) 
+                return;
+
+            Canvas.SetLeft(_textBlock, 0);
+            Canvas.SetTop(_textBlock,
+                Math.Max(0, (Bounds.Height - _textBlock.DesiredSize.Height) / 2));
+
+            if (textWidth <= Bounds.Width) 
+                return;
 
             _animationCts?.Cancel();
             _animationCts?.Dispose();
             _animationCts = new CancellationTokenSource();
             var token = _animationCts.Token;
 
-            if (Bounds.Width <= 0) return;
-
-            var textWidth = _textBlock.Bounds.Width > 0
-                ? _textBlock.Bounds.Width
-                : _textBlock.DesiredSize.Width;
-
-            if (textWidth <= 0)
-            {
-                RequestMarqueeStart();
-                return;
-            }
-
-            _canvas.Width = Bounds.Width;
-            _canvas.Height = Bounds.Height;
-
-            Canvas.SetLeft(_textBlock, 0);
-            Canvas.SetTop(_textBlock,
-                Math.Max(0, (Bounds.Height - _textBlock.Bounds.Height) / 2));
-
-            if (textWidth <= Bounds.Width) return;
-
             double startX = Bounds.Width;
             double endX = -textWidth;
+            double totalDistance = startX - endX;
+            var duration = TimeSpan.FromSeconds(totalDistance / ScrollSpeedPxPerSecond);
 
             var animation = new Animation
             {
-                Duration = TimeSpan.FromSeconds(8),
+                Duration = duration,
                 IterationCount = new IterationCount(1),
                 Easing = new LinearEasing(),
                 Children =
                 {
                     new KeyFrame
                     {
-                        Cue     = new Cue(0),
+                        Cue = new Cue(0),
                         Setters = { new Setter(Canvas.LeftProperty, startX) }
                     },
                     new KeyFrame
                     {
-                        Cue     = new Cue(1),
+                        Cue = new Cue(1),
                         Setters = { new Setter(Canvas.LeftProperty, endX) }
                     }
                 }
@@ -199,11 +229,42 @@ namespace ShadUI
                 }
             }
             catch (OperationCanceledException) { }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"[MarqueeTextBlock] Unexpected animation error: {ex}");
+            }
         }
 
         /// <summary>
-        /// Cancels all in-flight timers and animations, then disposes every
-        /// subscription and event handler to prevent memory leaks.
+        /// Unsubscribes all event handlers and nulls their references to break
+        /// closures and allow GC. Shared by <see cref="OnApplyTemplate"/> (re-apply guard)
+        /// and <see cref="OnDetachedFromVisualTree"/> (final cleanup).
+        /// </summary>
+        private void DetachEventHandlers()
+        {
+            if (_attachedHandler != null)
+            {
+                AttachedToVisualTree -= _attachedHandler;
+                _attachedHandler = null;
+            }
+
+            if (_sizeChangedHandler != null)
+            {
+                SizeChanged -= _sizeChangedHandler;
+                _sizeChangedHandler = null;
+            }
+
+            if (_classesChangedHandler != null)
+            {
+                ((INotifyCollectionChanged)Classes).CollectionChanged -= _classesChangedHandler;
+                _classesChangedHandler = null;
+            }
+        }
+
+        /// <summary>
+        /// Cancels all in-flight timers and animations, releases template part references,
+        /// then delegates to <see cref="DetachEventHandlers"/> to release all subscriptions.
         /// </summary>
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
@@ -217,23 +278,10 @@ namespace ShadUI
             _animationCts?.Dispose();
             _animationCts = null;
 
-            if (_attachedHandler != null)
-            {
-                this.AttachedToVisualTree -= _attachedHandler;
-                _attachedHandler = null;
-            }
+            _textBlock = null;
+            _canvas = null;
 
-            if (_sizeChangedHandler != null)
-            {
-                this.SizeChanged -= _sizeChangedHandler;
-                _sizeChangedHandler = null;
-            }
-
-            if (_classesChangedHandler != null && Classes is INotifyCollectionChanged incc)
-            {
-                incc.CollectionChanged -= _classesChangedHandler;
-                _classesChangedHandler = null;
-            }
+            DetachEventHandlers();
         }
 
         /// <summary>
@@ -247,7 +295,7 @@ namespace ShadUI
             if (change.Property == TextValueProperty)
             {
                 UpdateTextBlock();
-                _requestMarqueeStart?.Invoke();
+                RequestMarqueeStart();
             }
         }
     }

--- a/src/ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.cs
+++ b/src/ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
@@ -9,294 +10,299 @@ using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
 using Avalonia.Styling;
 
-namespace ShadUI
+namespace ShadUI;
+
+/// <summary>
+/// Scrolls text horizontally when its width exceeds the control bounds (marquee effect)
+/// Requires PART_Canvas and PART_Text in the control template
+/// </summary>
+public class MarqueeTextBlock : TemplatedControl
 {
     /// <summary>
-    /// Templated control that scrolls its text horizontally when the content
-    /// width exceeds the available bounds (marquee / ticker effect).
-    /// Requires PART_Canvas and PART_Text named parts in its control template.
+    /// Defines the <see cref="TextValue"/> property
     /// </summary>
-    public class MarqueeTextBlock : TemplatedControl
+    public static readonly StyledProperty<string> TextValueProperty =
+        AvaloniaProperty.Register<MarqueeTextBlock, string>(nameof(TextValue), defaultValue: string.Empty);
+
+    /// <summary>
+    /// Gets or sets the text displayed by this control
+    /// </summary>
+    public string TextValue
     {
-        /// <summary>
-        /// Defines the <see cref="TextValue"/> styled property
-        /// </summary>
-        public static readonly StyledProperty<string> TextValueProperty =
-            AvaloniaProperty.Register<MarqueeTextBlock, string>(nameof(TextValue), defaultValue: string.Empty);
+        get => GetValue(TextValueProperty);
+        set => SetValue(TextValueProperty, value);
+    }
 
-        /// <summary>
-        /// Gets or sets the text content displayed by this control
-        /// </summary>
-        public string TextValue
+    /// <summary>
+    /// Scrolling speed in pixels per second
+    /// Duration is derived from this so speed stays constant regardless of text length
+    /// </summary>
+    private const double ScrollSpeedPxPerSecond = 80.0;
+
+    private TextBlock? _textBlock;
+    private Canvas? _canvas;
+
+    private EventHandler<VisualTreeAttachmentEventArgs>? _attachedHandler;
+    private EventHandler<SizeChangedEventArgs>? _sizeChangedHandler;
+    private NotifyCollectionChangedEventHandler? _classesChangedHandler;
+
+    /// <summary>
+    /// Cancels the 150 ms debounce delay when a newer request arrives
+    /// </summary>
+    private CancellationTokenSource? _debounceCts;
+
+    /// <summary>
+    /// Cancels the running animation loop when a restart is needed
+    /// </summary>
+    private CancellationTokenSource? _animationCts;
+
+    /// <summary>
+    /// Resolves template parts, mirrors CSS classes, and wires up event subscriptions
+    /// Unsubscribes previous handlers first to handle theme re-application safely
+    /// </summary>
+    protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+    {
+        base.OnApplyTemplate(e);
+
+        DetachEventHandlers();
+
+        _textBlock = e.NameScope.Find<TextBlock>("PART_Text");
+        _canvas = e.NameScope.Find<Canvas>("PART_Canvas");
+
+        UpdateTextBlock();
+        UpdateClasses();
+
+        _classesChangedHandler = (_, _) => UpdateClasses();
+        _attachedHandler = (_, _) => RequestMarqueeStart();
+        _sizeChangedHandler = (_, _) => RequestMarqueeStart();
+
+        Classes.CollectionChanged += _classesChangedHandler;
+        AttachedToVisualTree += _attachedHandler;
+        SizeChanged += _sizeChangedHandler;
+
+        RequestMarqueeStart();
+    }
+
+    /// <summary>
+    /// Returns the TextBlock's natural height as the control's desired height
+    /// Needed because Canvas always reports (0, 0) and would otherwise collapse the control
+    /// </summary>
+    protected override Size MeasureOverride(Size availableSize)
+    {
+        var baseSize = base.MeasureOverride(availableSize);
+
+        if (_textBlock is null) 
+            return baseSize;
+
+        return new Size(baseSize.Width, _textBlock.DesiredSize.Height);
+    }
+
+    /// <summary>
+    /// Syncs <see cref="TextValue"/> into the inner TextBlock
+    /// </summary>
+    private void UpdateTextBlock()
+    {
+        if (_textBlock is null) 
+            return;
+
+        _textBlock.Text = TextValue ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Copies non-pseudo CSS classes to the inner TextBlock
+    /// so ShadUI typography classes (Small, Muted) are applied correctly
+    /// </summary>
+    private void UpdateClasses()
+    {
+        if (_textBlock is null) 
+            return;
+
+        _textBlock.Classes.Clear();
+
+        foreach (var c in Classes)
+            if (!c.StartsWith(':'))
+                _textBlock.Classes.Add(c);
+    }
+
+    /// <summary>
+    /// Cancels any pending debounce and schedules a new marquee start after 150 ms
+    /// Coalesces rapid layout and property-change events into a single restart
+    /// </summary>
+    private void RequestMarqueeStart()
+    {
+        if (_canvas is null) 
+            return;
+
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        _debounceCts = new CancellationTokenSource();
+
+        RunAfterDelay(_debounceCts.Token);
+    }
+
+    /// <summary>
+    /// Waits out the debounce delay, then calls <see cref="StartMarquee"/>
+    /// Exits silently if cancelled by a newer request
+    /// </summary>
+    private async void RunAfterDelay(CancellationToken debounceToken)
+    {
+        try
         {
-            get => GetValue(TextValueProperty);
-            set => SetValue(TextValueProperty, value);
+            await Task.Delay(150, debounceToken);
+
+            var cts = _debounceCts;
+            _debounceCts = null;
+            cts?.Dispose();
+
+            StartMarquee();
         }
+        catch (OperationCanceledException) { }
+    }
 
-        /// <summary>
-        /// Scrolling speed in pixels per second.
-        /// Duration is derived from this value so speed stays constant for any text length.
-        /// </summary>
-        private const double ScrollSpeedPxPerSecond = 80.0;
+    /// <summary>
+    /// Stops the current animation, then starts a new marquee loop if the text
+    /// overflows the control. Shows text statically if it fits
+    /// </summary>
+    private async void StartMarquee()
+    {
+        if (_textBlock is null || _canvas is null) 
+            return;
 
-        private TextBlock? _textBlock;
-        private Canvas? _canvas;
+        _animationCts?.Cancel();
+        _animationCts?.Dispose();
+        _animationCts = null;
 
+        if (!IsVisible || Bounds.Width <= 0) 
+            return;
 
-        private EventHandler<VisualTreeAttachmentEventArgs>? _attachedHandler;
-        private EventHandler<SizeChangedEventArgs>? _sizeChangedHandler;
-        private NotifyCollectionChangedEventHandler? _classesChangedHandler;
+        var textWidth = _textBlock.DesiredSize.Width;
 
-        /// <summary>
-        /// Cancels the 150 ms debounce delay when a newer request arrives
-        /// </summary>
-        private CancellationTokenSource? _debounceCts;
+        if (textWidth <= 0) 
+            return;
 
-        /// <summary>
-        /// Cancels the running animation loop when a restart is needed
-        /// </summary>
-        private CancellationTokenSource? _animationCts;
+        Canvas.SetLeft(_textBlock, 0);
+        Canvas.SetTop(_textBlock, Math.Max(0, (Bounds.Height - _textBlock.DesiredSize.Height) / 2));
 
+        if (textWidth <= Bounds.Width) 
+            return;
 
-        /// <summary>
-        /// Resolves PART_Canvas and PART_Text, mirrors CSS classes, and wires up
-        /// all subscriptions that trigger marquee re-evaluation.
-        /// Called on first apply and again on theme changes — old handlers are
-        /// always unsubscribed first to prevent duplicate firings and memory leaks.
-        /// </summary>
-        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+        _animationCts = new CancellationTokenSource();
+        var token = _animationCts.Token;
+
+        double startX = Bounds.Width;
+        double endX = -textWidth;
+        var duration = TimeSpan.FromSeconds((startX - endX) / ScrollSpeedPxPerSecond);
+
+        var animation = new Animation
         {
-            base.OnApplyTemplate(e);
-
-            DetachEventHandlers();
-
-            _textBlock = e.NameScope.Find<TextBlock>("PART_Text");
-            _canvas = e.NameScope.Find<Canvas>("PART_Canvas");
-
-            UpdateTextBlock();
-            UpdateClasses();
-
-            _classesChangedHandler = (_, _) => UpdateClasses();
-            _attachedHandler = (_, _) => RequestMarqueeStart();
-            _sizeChangedHandler = (_, _) => RequestMarqueeStart();
-
-            ((INotifyCollectionChanged)Classes).CollectionChanged += _classesChangedHandler;
-
-            AttachedToVisualTree += _attachedHandler;
-            SizeChanged += _sizeChangedHandler;
-
-            RequestMarqueeStart();
-        }
-
-        /// <summary>
-        /// Reports the TextBlock's natural height as the control's desired height.
-        /// Canvas always returns DesiredSize = (0, 0), so without this override the
-        /// control collapses and becomes invisible unless MinHeight is set explicitly.
-        /// <para>
-        /// After <c>base.MeasureOverride</c>, Canvas has already measured the TextBlock
-        /// with infinite space — no additional Measure call is needed.
-        /// </para>
-        /// </summary>
-        protected override Size MeasureOverride(Size availableSize)
-        {
-            var baseSize = base.MeasureOverride(availableSize);
-
-            if (_textBlock is null) 
-                return baseSize;
-
-            return new Size(baseSize.Width, _textBlock.DesiredSize.Height);
-        }
-
-
-        /// <summary>Pushes the current <see cref="TextValue"/> into the inner TextBlock.</summary>
-        private void UpdateTextBlock()
-        {
-            if (_textBlock is null) 
-                return;
-            _textBlock.Text = TextValue;
-        }
-
-        /// <summary>
-        /// Copies non-pseudo CSS classes from this control to the inner TextBlock
-        /// so that ShadUI typography classes (e.g. Small, Muted) are applied correctly.
-        /// </summary>
-        private void UpdateClasses()
-        {
-            if (_textBlock is null) 
-                return;
-
-            _textBlock.Classes.Clear();
-            foreach (var c in Classes)
-                if (!c.StartsWith(':'))
-                    _textBlock.Classes.Add(c);
-        }
-
-        /// <summary>
-        /// Cancels any pending debounce timer and schedules a fresh marquee start
-        /// after 150 ms to coalesce rapid layout/property-change events.
-        /// </summary>
-        private void RequestMarqueeStart()
-        {
-            _debounceCts?.Cancel();
-            _debounceCts?.Dispose();
-            _debounceCts = new CancellationTokenSource();
-            RunAfterDelay(_debounceCts.Token);
-        }
-
-        /// <summary>
-        /// Waits for the debounce delay, disposes the completed CTS, then forwards
-        /// to <see cref="StartMarquee"/>. Exits silently if cancelled.
-        /// </summary>
-        private async void RunAfterDelay(CancellationToken debounceToken)
-        {
-            try
+            Duration = duration,
+            IterationCount = new IterationCount(1),
+            Easing = new LinearEasing(),
+            Children =
             {
-                await Task.Delay(150, debounceToken);
-
-                _debounceCts?.Dispose();
-                _debounceCts = null;
-
-                StartMarquee();
-            }
-            catch (OperationCanceledException) { }
-        }
-
-        /// <summary>
-        /// Starts a new marquee loop when the text is wider than the control,
-        /// or positions the text statically when it fits.
-        /// <para>
-        /// All guard checks run before the <see cref="CancellationTokenSource"/> is
-        /// allocated, so no CTS is ever created for a no-op call.
-        /// </para>
-        /// </summary>
-        private async void StartMarquee()
-        {
-            if (_textBlock is null || _canvas is null) 
-                return;
-
-            if (Bounds.Width <= 0) 
-                return;
-
-            var textWidth = _textBlock.DesiredSize.Width;
-            if (textWidth <= 0) 
-                return;
-
-            Canvas.SetLeft(_textBlock, 0);
-            Canvas.SetTop(_textBlock,
-                Math.Max(0, (Bounds.Height - _textBlock.DesiredSize.Height) / 2));
-
-            if (textWidth <= Bounds.Width) 
-                return;
-
-            _animationCts?.Cancel();
-            _animationCts?.Dispose();
-            _animationCts = new CancellationTokenSource();
-            var token = _animationCts.Token;
-
-            double startX = Bounds.Width;
-            double endX = -textWidth;
-            double totalDistance = startX - endX;
-            var duration = TimeSpan.FromSeconds(totalDistance / ScrollSpeedPxPerSecond);
-
-            var animation = new Animation
-            {
-                Duration = duration,
-                IterationCount = new IterationCount(1),
-                Easing = new LinearEasing(),
-                Children =
+                new KeyFrame
                 {
-                    new KeyFrame
+                    Cue = new Cue(0),
+                    Setters =
                     {
-                        Cue = new Cue(0),
-                        Setters = { new Setter(Canvas.LeftProperty, startX) }
-                    },
-                    new KeyFrame
+                        new Setter(Canvas.LeftProperty, startX)
+                    }
+                },
+                new KeyFrame
+                {
+                    Cue = new Cue(1),
+                    Setters =
                     {
-                        Cue = new Cue(1),
-                        Setters = { new Setter(Canvas.LeftProperty, endX) }
+                        new Setter(Canvas.LeftProperty, endX)
                     }
                 }
-            };
-
-            try
-            {
-                while (!token.IsCancellationRequested)
-                {
-                    Canvas.SetLeft(_textBlock, startX);
-                    await animation.RunAsync(_textBlock, token);
-
-                    await Task.Delay(TimeSpan.FromSeconds(2), token);
-                }
             }
-            catch (OperationCanceledException) { }
-            catch (Exception ex)
-            {
-                System.Diagnostics.Debug.WriteLine(
-                    $"[MarqueeTextBlock] Unexpected animation error: {ex}");
-            }
-        }
+        };
 
-        /// <summary>
-        /// Unsubscribes all event handlers and nulls their references to break
-        /// closures and allow GC. Shared by <see cref="OnApplyTemplate"/> (re-apply guard)
-        /// and <see cref="OnDetachedFromVisualTree"/> (final cleanup).
-        /// </summary>
-        private void DetachEventHandlers()
+        try
         {
-            if (_attachedHandler != null)
+            while (!token.IsCancellationRequested)
             {
-                AttachedToVisualTree -= _attachedHandler;
-                _attachedHandler = null;
-            }
-
-            if (_sizeChangedHandler != null)
-            {
-                SizeChanged -= _sizeChangedHandler;
-                _sizeChangedHandler = null;
-            }
-
-            if (_classesChangedHandler != null)
-            {
-                ((INotifyCollectionChanged)Classes).CollectionChanged -= _classesChangedHandler;
-                _classesChangedHandler = null;
+                Canvas.SetLeft(_textBlock, startX);
+                await animation.RunAsync(_textBlock, token);
+                await Task.Delay(TimeSpan.FromSeconds(2), token);
             }
         }
-
-        /// <summary>
-        /// Cancels all in-flight timers and animations, releases template part references,
-        /// then delegates to <see cref="DetachEventHandlers"/> to release all subscriptions.
-        /// </summary>
-        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        catch (OperationCanceledException) { }
+        catch (Exception ex)
         {
-            base.OnDetachedFromVisualTree(e);
-
-            _debounceCts?.Cancel();
-            _debounceCts?.Dispose();
-            _debounceCts = null;
-
-            _animationCts?.Cancel();
-            _animationCts?.Dispose();
-            _animationCts = null;
-
-            _textBlock = null;
-            _canvas = null;
-
-            DetachEventHandlers();
+            Debug.WriteLine($"[MarqueeTextBlock] Unexpected animation error: {ex}");
         }
-
-        /// <summary>
-        /// Reacts to property changes — updates the inner TextBlock text
-        /// and requests a marquee restart when <see cref="TextValue"/> changes.
-        /// </summary>
-        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        finally
         {
-            base.OnPropertyChanged(change);
-
-            if (change.Property == TextValueProperty)
+            if (_animationCts?.Token == token)
             {
-                UpdateTextBlock();
-                RequestMarqueeStart();
+                _animationCts.Dispose();
+                _animationCts = null;
             }
         }
+    }
+
+    /// <summary>
+    /// Unsubscribes and nulls all event handlers
+    /// Called on template re-application and on detach from the visual tree
+    /// </summary>
+    private void DetachEventHandlers()
+    {
+        if (_attachedHandler != null)
+        {
+            AttachedToVisualTree -= _attachedHandler;
+            _attachedHandler = null;
+        }
+
+        if (_sizeChangedHandler != null)
+        {
+            SizeChanged -= _sizeChangedHandler;
+            _sizeChangedHandler = null;
+        }
+
+        if (_classesChangedHandler != null)
+        {
+            Classes.CollectionChanged -= _classesChangedHandler;
+            _classesChangedHandler = null;
+        }
+    }
+
+    /// <summary>
+    /// Cancels all timers and animations, releases template part references, and unsubscribes all event handlers
+    /// </summary>
+    protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+    {
+        base.OnDetachedFromVisualTree(e);
+
+        _debounceCts?.Cancel();
+        _debounceCts?.Dispose();
+        _debounceCts = null;
+
+        _animationCts?.Cancel();
+        _animationCts?.Dispose();
+        _animationCts = null;
+
+        _textBlock = null;
+        _canvas = null;
+
+        DetachEventHandlers();
+    }
+
+    /// <summary>
+    /// Handles <see cref="TextValueProperty"/> changes by refreshing text and restarting the marquee,
+    /// and <see cref="Visual.IsVisibleProperty"/> changes by restarting or stopping it
+    /// </summary>
+    protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+    {
+        base.OnPropertyChanged(change);
+
+        if (change.Property == TextValueProperty)
+        {
+            UpdateTextBlock();
+            RequestMarqueeStart();
+        }
+        else if (change.Property == IsVisibleProperty)
+            RequestMarqueeStart();
     }
 }

--- a/src/ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.cs
+++ b/src/ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.cs
@@ -1,0 +1,254 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Animation;
+using Avalonia.Animation.Easings;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Styling;
+
+namespace ShadUI
+{
+    /// <summary>
+    /// A templated control that scrolls its text horizontally when the content
+    /// width exceeds the available bounds (marquee / ticker effect).
+    /// Requires PART_Canvas and PART_Text named parts in its control template.
+    /// </summary>
+    public class MarqueeTextBlock : TemplatedControl
+    {
+        /// <summary>
+        /// Defines the <see cref="TextValue"/> styled property
+        /// </summary>
+        public static readonly StyledProperty<string> TextValueProperty =
+            AvaloniaProperty.Register<MarqueeTextBlock, string>(nameof(TextValue));
+
+        /// <summary>
+        /// Gets or sets the text content displayed by this control
+        /// </summary>
+        public string TextValue
+        {
+            get => GetValue(TextValueProperty);
+            set => SetValue(TextValueProperty, value);
+        }
+
+        private TextBlock? _textBlock;
+        private Canvas? _canvas;
+
+        private Action? _requestMarqueeStart;
+        private EventHandler<VisualTreeAttachmentEventArgs>? _attachedHandler;
+        private EventHandler<SizeChangedEventArgs>? _sizeChangedHandler;
+        private NotifyCollectionChangedEventHandler? _classesChangedHandler;
+
+        /// <summary>
+        /// Cancels the 150 ms debounce delay when a newer request arrives
+        /// </summary>
+        private CancellationTokenSource? _debounceCts;
+
+        /// <summary>
+        /// Cancels the running animation loop when a restart is needed
+        /// </summary>
+        private CancellationTokenSource? _animationCts;
+
+        /// <summary>
+        /// Resolves PART_Canvas and PART_Text, mirrors CSS classes, and wires up
+        /// all subscriptions that trigger marquee re-evaluation
+        /// </summary>
+        protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+        {
+            base.OnApplyTemplate(e);
+
+            _textBlock = e.NameScope.Find<TextBlock>("PART_Text");
+            _canvas = e.NameScope.Find<Canvas>("PART_Canvas");
+
+            UpdateTextBlock();
+            UpdateClasses();
+
+            _requestMarqueeStart = RequestMarqueeStart;
+
+            _classesChangedHandler = (_, _) => UpdateClasses();
+            if (Classes is INotifyCollectionChanged incc)
+                incc.CollectionChanged += _classesChangedHandler;
+
+            _attachedHandler = (_, _) => _requestMarqueeStart();
+            _sizeChangedHandler = (_, _) => _requestMarqueeStart();
+            this.AttachedToVisualTree += _attachedHandler;
+            this.SizeChanged += _sizeChangedHandler;
+
+            _requestMarqueeStart();
+        }
+
+
+        /// <summary>
+        /// Pushes the current <see cref="TextValue"/> into the inner TextBlock
+        /// </summary>
+        private void UpdateTextBlock()
+        {
+            if (_textBlock is null) return;
+            _textBlock.Text = TextValue;
+        }
+
+        /// <summary>
+        /// Copies non-pseudo CSS classes from this control to the inner TextBlock
+        /// so that ShadUI typography classes (e.g. Small, Muted) are applied correctly.
+        /// </summary>
+        private void UpdateClasses()
+        {
+            if (_textBlock is null) return;
+
+            _textBlock.Classes.Clear();
+            foreach (var c in Classes)
+                if (!c.StartsWith(':'))
+                    _textBlock.Classes.Add(c);
+        }
+
+
+        /// <summary>
+        /// Cancels any pending debounce timer and schedules a fresh marquee start
+        /// after 150 ms to coalesce rapid layout/property-change events.
+        /// </summary>
+        private void RequestMarqueeStart()
+        {
+            _debounceCts?.Cancel();
+            _debounceCts?.Dispose();
+            _debounceCts = new CancellationTokenSource();
+            RunAfterDelay(_debounceCts.Token);
+        }
+
+        /// <summary>
+        /// Waits for the debounce delay then forwards to <see cref="StartMarquee"/>.
+        /// Exits silently if cancelled before the delay completes.
+        /// </summary>
+        private async void RunAfterDelay(CancellationToken debounceToken)
+        {
+            try
+            {
+                await Task.Delay(150, debounceToken);
+                StartMarquee();
+            }
+            catch (OperationCanceledException) { }
+        }
+
+        /// <summary>
+        /// Cancels any running animation, then starts a new marquee loop when the
+        /// text is wider than the control. Resets the TextBlock position when not scrolling.
+        /// The TextBlock is vertically centred inside the Canvas at startup.
+        /// </summary>
+        private async void StartMarquee()
+        {
+            if (_textBlock is null || _canvas is null) return;
+
+            _animationCts?.Cancel();
+            _animationCts?.Dispose();
+            _animationCts = new CancellationTokenSource();
+            var token = _animationCts.Token;
+
+            if (Bounds.Width <= 0) return;
+
+            var textWidth = _textBlock.Bounds.Width > 0
+                ? _textBlock.Bounds.Width
+                : _textBlock.DesiredSize.Width;
+
+            if (textWidth <= 0)
+            {
+                RequestMarqueeStart();
+                return;
+            }
+
+            _canvas.Width = Bounds.Width;
+            _canvas.Height = Bounds.Height;
+
+            Canvas.SetLeft(_textBlock, 0);
+            Canvas.SetTop(_textBlock,
+                Math.Max(0, (Bounds.Height - _textBlock.Bounds.Height) / 2));
+
+            if (textWidth <= Bounds.Width) return;
+
+            double startX = Bounds.Width;
+            double endX = -textWidth;
+
+            var animation = new Animation
+            {
+                Duration = TimeSpan.FromSeconds(8),
+                IterationCount = new IterationCount(1),
+                Easing = new LinearEasing(),
+                Children =
+                {
+                    new KeyFrame
+                    {
+                        Cue     = new Cue(0),
+                        Setters = { new Setter(Canvas.LeftProperty, startX) }
+                    },
+                    new KeyFrame
+                    {
+                        Cue     = new Cue(1),
+                        Setters = { new Setter(Canvas.LeftProperty, endX) }
+                    }
+                }
+            };
+
+            try
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    Canvas.SetLeft(_textBlock, startX);
+                    await animation.RunAsync(_textBlock, token);
+
+                    await Task.Delay(TimeSpan.FromSeconds(2), token);
+                }
+            }
+            catch (OperationCanceledException) { }
+        }
+
+        /// <summary>
+        /// Cancels all in-flight timers and animations, then disposes every
+        /// subscription and event handler to prevent memory leaks.
+        /// </summary>
+        protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
+        {
+            base.OnDetachedFromVisualTree(e);
+
+            _debounceCts?.Cancel();
+            _debounceCts?.Dispose();
+            _debounceCts = null;
+
+            _animationCts?.Cancel();
+            _animationCts?.Dispose();
+            _animationCts = null;
+
+            if (_attachedHandler != null)
+            {
+                this.AttachedToVisualTree -= _attachedHandler;
+                _attachedHandler = null;
+            }
+
+            if (_sizeChangedHandler != null)
+            {
+                this.SizeChanged -= _sizeChangedHandler;
+                _sizeChangedHandler = null;
+            }
+
+            if (_classesChangedHandler != null && Classes is INotifyCollectionChanged incc)
+            {
+                incc.CollectionChanged -= _classesChangedHandler;
+                _classesChangedHandler = null;
+            }
+        }
+
+        /// <summary>
+        /// Reacts to property changes — updates the inner TextBlock text
+        /// and requests a marquee restart when <see cref="TextValue"/> changes.
+        /// </summary>
+        protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+        {
+            base.OnPropertyChanged(change);
+
+            if (change.Property == TextValueProperty)
+            {
+                UpdateTextBlock();
+                _requestMarqueeStart?.Invoke();
+            }
+        }
+    }
+}

--- a/src/ShadUI/Controls/NumericUpDown/ButtonSpinner.axaml
+++ b/src/ShadUI/Controls/NumericUpDown/ButtonSpinner.axaml
@@ -178,7 +178,7 @@
             </Setter>
             <Setter Property="BorderBrush" Value="{DynamicResource PrimaryColor}" />
         </Style>
-        <Style Selector="^:not(:error):focus /template/ Border#border">
+        <Style Selector="^:not(:error):focus-within /template/ Border#border">
             <Setter Property="Transitions">
                 <Setter.Value>
                     <Transitions>

--- a/src/ShadUI/Controls/NumericUpDown/NumericUpDown.axaml
+++ b/src/ShadUI/Controls/NumericUpDown/NumericUpDown.axaml
@@ -118,6 +118,7 @@
         </Style>
     </ControlTheme>
     <ControlTheme TargetType="NumericUpDown" x:Key="{x:Type NumericUpDown}">
+        <Setter Property="shadui:NumericUpDownAssist.NumericOnly" Value="True" />
         <Setter Property="Background" Value="{DynamicResource SelectionColor}" />
         <Setter Property="BorderBrush" Value="{DynamicResource BorderColor}" />
         <Setter Property="CornerRadius" Value="{DynamicResource LgCornerRadius}" />

--- a/src/ShadUI/Controls/RadioButton/RadioButton.axaml
+++ b/src/ShadUI/Controls/RadioButton/RadioButton.axaml
@@ -1,0 +1,93 @@
+<ResourceDictionary
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Design.PreviewWith>
+        <Border Padding="24">
+            <StackPanel Spacing="16">
+                <RadioButton GroupName="preview">Option 1</RadioButton>
+                <RadioButton GroupName="preview" IsChecked="True">Option 2 (Selected)</RadioButton>
+                <RadioButton GroupName="preview" IsEnabled="False">Option 3 (Disabled)</RadioButton>
+            </StackPanel>
+        </Border>
+    </Design.PreviewWith>
+    <ControlTheme TargetType="RadioButton" x:Key="{x:Type RadioButton}">
+        <Setter Property="Foreground" Value="{DynamicResource ForegroundColor}" />
+        <Setter Property="Background" Value="{DynamicResource SelectionColor}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource BorderColor}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Setter Property="Padding" Value="4,0,0,0" />
+        <Setter Property="VerticalContentAlignment" Value="Center" />
+        <Setter Property="TextBlock.FontSize" Value="14" />
+        <Setter Property="TextBlock.FontWeight" Value="Medium" />
+        <Setter Property="HorizontalContentAlignment" Value="Left" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <StackPanel
+                    Background="Transparent"
+                    Orientation="Horizontal"
+                    Spacing="4">
+                    <Border
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        CornerRadius="10"
+                        Height="18"
+                        Name="OuterBorder"
+                        VerticalAlignment="Center"
+                        Width="18">
+                        <Ellipse
+                            Fill="{DynamicResource PrimaryColor}"
+                            Height="10"
+                            HorizontalAlignment="Center"
+                            Name="CheckGlyph"
+                            VerticalAlignment="Center"
+                            Width="10" />
+                    </Border>
+                    <ContentPresenter
+                        Content="{TemplateBinding Content}"
+                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                        HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        IsVisible="{TemplateBinding Content,
+                                                    Converter={x:Static ObjectConverters.IsNotNull}}"
+                        Margin="{TemplateBinding Padding}"
+                        Name="PART_ContentPresenter"
+                        RecognizesAccessKey="True"
+                        TextElement.Foreground="{TemplateBinding Foreground}"
+                        VerticalAlignment="{TemplateBinding VerticalContentAlignment}" />
+                </StackPanel>
+            </ControlTemplate>
+        </Setter>
+        <Style Selector="^:pointerover /template/ Border#OuterBorder">
+            <Setter Property="Transitions">
+                <Setter.Value>
+                    <Transitions>
+                        <BrushTransition Duration="0:0:0.20" Property="BorderBrush" />
+                    </Transitions>
+                </Setter.Value>
+            </Setter>
+            <Setter Property="BorderBrush" Value="{DynamicResource PrimaryColor}" />
+        </Style>
+        <!-- Hide check glyph by default -->
+        <Style Selector="^ /template/ Ellipse#CheckGlyph">
+            <Setter Property="IsVisible" Value="False" />
+        </Style>
+        <!-- Show check glyph when checked -->
+        <Style Selector="^:checked">
+            <Style Selector="^ /template/ Ellipse#CheckGlyph">
+                <Setter Property="IsVisible" Value="True" />
+            </Style>
+            <Style Selector="^ /template/ Border#OuterBorder">
+                <Setter Property="BorderBrush" Value="{DynamicResource PrimaryColor}" />
+            </Style>
+        </Style>
+        <!-- Disabled state -->
+        <Style Selector="^:disabled">
+            <Style Selector="^ /template/ Border#OuterBorder">
+                <Setter Property="Opacity" Value="0.5" />
+            </Style>
+            <Style Selector="^ /template/ ContentPresenter#PART_ContentPresenter">
+                <Setter Property="Opacity" Value="0.5" />
+            </Style>
+        </Style>
+    </ControlTheme>
+</ResourceDictionary>

--- a/src/ShadUI/Controls/Resources.axaml
+++ b/src/ShadUI/Controls/Resources.axaml
@@ -36,6 +36,7 @@
         <ResourceInclude Source="avares://ShadUI/Controls/Menu/MenuItem.axaml" />
         <ResourceInclude Source="avares://ShadUI/Controls/NumericUpDown/ButtonSpinner.axaml" />
         <ResourceInclude Source="avares://ShadUI/Controls/NumericUpDown/NumericUpDown.axaml" />
+        <ResourceInclude Source="avares://ShadUI/Controls/RadioButton/RadioButton.axaml" />
         <ResourceInclude Source="avares://ShadUI/Controls/SelectableTextBlock/SelectableTextBlock.axaml" />
         <ResourceInclude Source="avares://ShadUI/Controls/Sidebar/Sidebar.axaml" />
         <ResourceInclude Source="avares://ShadUI/Controls/Sidebar/SidebarItem.axaml" />

--- a/src/ShadUI/Controls/Resources.axaml
+++ b/src/ShadUI/Controls/Resources.axaml
@@ -49,6 +49,7 @@
         <ResourceInclude Source="avares://ShadUI/Controls/TabControl/TabItem.axaml" />
         <ResourceInclude Source="avares://ShadUI/Controls/TextBox/TextBox.axaml" />
         <ResourceInclude Source="avares://ShadUI/Controls/TextBlock/TextBlock.axaml" />
+        <ResourceInclude Source="avares://ShadUI/Controls/MarqueeTextBlock/MarqueeTextBlock.axaml"/>
         <ResourceInclude Source="avares://ShadUI/Controls/TimeInput/TimeInput.axaml" />
         <ResourceInclude Source="avares://ShadUI/Controls/TimePicker/TimePicker.axaml" />
         <ResourceInclude Source="avares://ShadUI/Controls/Toast/Toast.axaml" />

--- a/src/ShadUI/Controls/ScrollViewer/ScrollBarStyles.axaml
+++ b/src/ShadUI/Controls/ScrollViewer/ScrollBarStyles.axaml
@@ -40,11 +40,13 @@
                                                 Background="{DynamicResource BorderColor}"
                                                 CornerRadius="{DynamicResource MdCornerRadius}"
                                                 Name="ThumbBarVertical"
-                                                Width="2">
+                                                Width="2"
+                                                Margin="0,10">
                                                 <Border.Transitions>
                                                     <Transitions>
                                                         <BrushTransition Duration="0:0:0.15" Property="Background" />
                                                         <DoubleTransition Duration="0:0:0.1" Property="Width" />
+                                                        <ThicknessTransition Duration="0:0:0.1" Property="Margin" />
                                                     </Transitions>
                                                 </Border.Transitions>
                                             </Border>
@@ -153,12 +155,14 @@
                                             <Border
                                                 Background="{DynamicResource BorderColor}"
                                                 CornerRadius="{DynamicResource MdCornerRadius}"
+                                                Name="ThumbBarHorizontal"
                                                 Height="2"
-                                                Name="ThumbBarHorizontal">
+                                                Margin="10,0">
                                                 <Border.Transitions>
                                                     <Transitions>
                                                         <BrushTransition Duration="0:0:0.15" Property="Background" />
                                                         <DoubleTransition Duration="0:0:0.1" Property="Height" />
+                                                        <ThicknessTransition Duration="0:0:0.1" Property="Margin" />
                                                     </Transitions>
                                                 </Border.Transitions>
                                             </Border>
@@ -180,12 +184,14 @@
     <Style Selector="ScrollBar[AllowAutoHide=True] Border#ThumbBarVertical">
         <Setter Property="Background" Value="{DynamicResource BorderColor}" />
         <Setter Property="Width" Value="6" />
+        <Setter Property="Margin" Value="0, 6" />
     </Style>
 
 
     <Style Selector="ScrollBar[AllowAutoHide=True] Border#ThumbBarHorizontal">
         <Setter Property="Background" Value="{DynamicResource BorderColor}" />
         <Setter Property="Height" Value="6" />
+        <Setter Property="Margin" Value="6, 0" />
     </Style>
 
 </Styles>

--- a/src/ShadUI/Controls/ScrollViewer/ScrollViewerStyles.axaml
+++ b/src/ShadUI/Controls/ScrollViewer/ScrollViewerStyles.axaml
@@ -3,8 +3,8 @@
     xmlns:shadui="clr-namespace:ShadUI"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Style Selector="ScrollViewer">
-        <Setter Property="IsScrollInertiaEnabled" Value="True" />
-        <Setter Property="Template">
+        <Setter Property="shadui:SmoothScrollAssist.IsEnabled" Value="True" />
+		<Setter Property="Template">
             <ControlTemplate>
                 <Panel>
                     <Panel Name="InnerPanel">

--- a/src/ShadUI/Controls/ScrollViewer/ScrollViewerStyles.axaml
+++ b/src/ShadUI/Controls/ScrollViewer/ScrollViewerStyles.axaml
@@ -1,9 +1,16 @@
-﻿<Styles
+﻿<!-- xmlns:system="clr-namespace:System;assembly=netstandard" 
+is use for x:TypeArguments="system:Double" DO NOT REMOVE -->
+<Styles
     xmlns="https://github.com/avaloniaui"
     xmlns:shadui="clr-namespace:ShadUI"
+    xmlns:system="clr-namespace:System;assembly=netstandard"  
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Style Selector="ScrollViewer">
         <Setter Property="shadui:SmoothScrollAssist.IsEnabled" Value="True" />
+        <Setter Property="shadui:SmoothScrollAssist.BaseStepSize"
+                Value="{OnPlatform 70.0, macOS=40.0, x:TypeArguments=system:Double}" />
+        <Setter Property="shadui:SmoothScrollAssist.SmoothingFactor"
+                Value="{OnPlatform 20.0, macOS=50.0, x:TypeArguments=system:Double}" />
 		<Setter Property="Template">
             <ControlTemplate>
                 <Panel>

--- a/src/ShadUI/Controls/TextBlock/TextBlock.axaml
+++ b/src/ShadUI/Controls/TextBlock/TextBlock.axaml
@@ -9,36 +9,30 @@
         </Style>
         <Style Selector="^.h2">
             <Setter Property="FontSize" Value="30" />
-            <Setter Property="LineHeight" Value="36" />
             <Setter Property="FontWeight" Value="SemiBold" />
         </Style>
 
         <Style Selector="^.h3">
             <Setter Property="FontSize" Value="24" />
-            <Setter Property="LineHeight" Value="32" />
             <Setter Property="FontWeight" Value="SemiBold" />
         </Style>
 
         <Style Selector="^.h4">
             <Setter Property="FontSize" Value="20" />
-            <Setter Property="LineHeight" Value="28" />
             <Setter Property="FontWeight" Value="SemiBold" />
         </Style>
 
         <Style Selector="^.p">
             <Setter Property="FontSize" Value="16" />
-            <Setter Property="LineHeight" Value="28" />
         </Style>
 
         <Style Selector="^.Lead">
             <Setter Property="FontSize" Value="20" />
-            <Setter Property="LineHeight" Value="28" />
             <Setter Property="Foreground" Value="{DynamicResource ForegroundLeadColor}" />
         </Style>
 
         <Style Selector="^.Large">
             <Setter Property="FontSize" Value="18" />
-            <Setter Property="LineHeight" Value="28" />
             <Setter Property="FontWeight" Value="SemiBold" />
         </Style>
 

--- a/src/ShadUI/Controls/TimePicker/TimePicker.axaml
+++ b/src/ShadUI/Controls/TimePicker/TimePicker.axaml
@@ -356,7 +356,7 @@
                                 </Style>
                             </Grid.Styles>
                             <Panel Grid.Column="0" Name="PART_HourHost">
-                                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Hidden">
+                                <ScrollViewer shadui:SmoothScrollAssist.IsEnabled="False" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Hidden">
                                     <DateTimePickerPanel
                                         ItemHeight="40"
                                         Name="PART_HourSelector"
@@ -368,7 +368,7 @@
                             </Panel>
 
                             <Panel Grid.Column="2" Name="PART_MinuteHost">
-                                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Hidden">
+                                <ScrollViewer shadui:SmoothScrollAssist.IsEnabled="False" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Hidden">
                                     <DateTimePickerPanel
                                         ItemHeight="40"
                                         Name="PART_MinuteSelector"
@@ -380,7 +380,7 @@
                             </Panel>
 
                             <Panel Grid.Column="4" Name="PART_SecondHost">
-                                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Hidden">
+                                <ScrollViewer shadui:SmoothScrollAssist.IsEnabled="False" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Hidden">
                                     <DateTimePickerPanel
                                         ItemHeight="40"
                                         Name="PART_SecondSelector"
@@ -392,7 +392,7 @@
                             </Panel>
 
                             <Panel Grid.Column="6" Name="PART_PeriodHost">
-                                <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Hidden">
+                                <ScrollViewer shadui:SmoothScrollAssist.IsEnabled="False" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Hidden">
                                     <DateTimePickerPanel
                                         ItemHeight="40"
                                         Name="PART_PeriodSelector"
@@ -410,8 +410,7 @@
                                 Height="40"
                                 Margin="4,0"
                                 Name="HighlightRect"
-                                VerticalAlignment="Center"
-                                ZIndex="-1" />
+                                VerticalAlignment="Center"/>
                             <Rectangle
                                 Grid.Column="1"
                                 HorizontalAlignment="Center"

--- a/src/ShadUI/Controls/Window/Window.axaml
+++ b/src/ShadUI/Controls/Window/Window.axaml
@@ -162,14 +162,8 @@
                                                             Name="AppTitlePanel"
                                                             Orientation="Horizontal"
                                                             Spacing="10"
-                                                            VerticalAlignment="Center">
-                                                            <StackPanel.IsVisible>
-                                                                <OnPlatform
-                                                                    Linux="True"
-                                                                    Windows="True"
-                                                                    macOS="False"
-                                                                    x:TypeArguments="system:Boolean" />
-                                                            </StackPanel.IsVisible>
+                                                            VerticalAlignment="Center"
+                                                            HorizontalAlignment="{OnPlatform Left, macOS=Center}">
                                                             <ContentPresenter
                                                                 Content="{TemplateBinding LogoContent}"
                                                                 HorizontalAlignment="Left"

--- a/src/ShadUI/Extensions/WindowExt.cs
+++ b/src/ShadUI/Extensions/WindowExt.cs
@@ -24,6 +24,17 @@ public static class WindowExt
     private static readonly Dictionary<string, WindowSettings?> Cache = new();
     private static readonly object CacheLock = new();
 
+    private static string GetSettingsDirectory()
+    {
+        var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        var shadUiDir = Path.Combine(localAppData, "ShadUI");
+
+        if (!Directory.Exists(shadUiDir))
+            Directory.CreateDirectory(shadUiDir);
+
+        return shadUiDir;
+    }
+
     /// <summary>
     ///     Enables automatic window state management for the specified window.
     ///     The window's position, size, and state will be automatically saved when the window closes
@@ -38,7 +49,7 @@ public static class WindowExt
     {
         if (ClosingHandlers.ContainsKey(window)) return;
 
-        var file = Path.Combine(Path.GetTempPath(), $"shadui_{key}.txt");
+        var file = Path.Combine(GetSettingsDirectory(), $"shadui_{key}.txt");
         RestoreWindowState(window, file);
 
         EventHandler<WindowClosingEventArgs> closingHandler = async void (_, _) =>

--- a/src/ShadUI/ShadUI.csproj
+++ b/src/ShadUI/ShadUI.csproj
@@ -23,14 +23,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.3.8" />
-        <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.3.8" />
-        <PackageReference Include="MinVer" Version="6.0.0">
+        <PackageReference Include="Avalonia" Version="11.3.10" />
+        <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.3.10" />
+        <PackageReference Include="MinVer" Version="7.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Avalonia.Themes.Simple" Version="11.3.8" />
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.8" />
+        <PackageReference Include="Avalonia.Themes.Simple" Version="11.3.10" />
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.10" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/ShadUI/Utilities/MacOS/ObjCRuntime.cs
+++ b/src/ShadUI/Utilities/MacOS/ObjCRuntime.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace ShadUI.Utilities.MacOS;
+
+/// <summary>
+/// Provides P/Invoke declarations for Objective-C runtime interop on macOS.
+/// </summary>
+internal static class ObjCRuntime
+{
+    private const string ObjCLibrary = "/usr/lib/libobjc.dylib";
+
+    /// <summary>
+    /// Creates a selector from a string name.
+    /// </summary>
+    [DllImport(ObjCLibrary, EntryPoint = "sel_registerName")]
+    public static extern IntPtr GetSelector(string name);
+
+    /// <summary>
+    /// Sends a message to an object and returns an IntPtr.
+    /// </summary>
+    [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
+    public static extern IntPtr SendMessage(IntPtr receiver, IntPtr selector);
+
+    /// <summary>
+    /// Sends a message with an int parameter.
+    /// </summary>
+    [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
+    public static extern IntPtr SendMessage(IntPtr receiver, IntPtr selector, int arg1);
+
+    /// <summary>
+    /// Sends a message with a CGPoint parameter (for setFrameOrigin:).
+    /// CGPoint is passed as two doubles on ARM64.
+    /// </summary>
+    [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
+    public static extern void SendMessage(IntPtr receiver, IntPtr selector, double x, double y);
+
+    /// <summary>
+    /// Sends a message to get a CGRect (frame). On ARM64, returns via registers.
+    /// </summary>
+    [DllImport(ObjCLibrary, EntryPoint = "objc_msgSend")]
+    public static extern CGRect SendMessageCGRect(IntPtr receiver, IntPtr selector);
+
+    /// <summary>
+    /// Represents a CGRect structure for frame operations.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct CGRect
+    {
+        public double X;
+        public double Y;
+        public double Width;
+        public double Height;
+    }
+
+    private static IntPtr _standardWindowButtonSelector;
+    private static IntPtr _frameSelector;
+    private static IntPtr _setFrameOriginSelector;
+    private static IntPtr _superviewSelector;
+
+    public static IntPtr StandardWindowButtonSelector =>
+        _standardWindowButtonSelector != IntPtr.Zero
+            ? _standardWindowButtonSelector
+            : (_standardWindowButtonSelector = GetSelector("standardWindowButton:"));
+
+    public static IntPtr FrameSelector =>
+        _frameSelector != IntPtr.Zero
+            ? _frameSelector
+            : (_frameSelector = GetSelector("frame"));
+
+    public static IntPtr SetFrameOriginSelector =>
+        _setFrameOriginSelector != IntPtr.Zero
+            ? _setFrameOriginSelector
+            : (_setFrameOriginSelector = GetSelector("setFrameOrigin:"));
+
+    public static IntPtr SuperviewSelector =>
+        _superviewSelector != IntPtr.Zero
+            ? _superviewSelector
+            : (_superviewSelector = GetSelector("superview"));
+}

--- a/src/ShadUI/Utilities/MacOS/TrafficLightHelper.cs
+++ b/src/ShadUI/Utilities/MacOS/TrafficLightHelper.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Runtime.InteropServices;
+using Avalonia;
+
+namespace ShadUI.Utilities.MacOS;
+
+/// <summary>
+/// Helper class for repositioning macOS traffic light buttons (close, minimize, zoom).
+/// </summary>
+internal static class TrafficLightHelper
+{
+    private enum NSWindowButton
+    {
+        Close = 0,
+        Miniaturize = 1,
+        Zoom = 2
+    }
+
+    // Default macOS traffic light positions (distance from edges)
+    private const double DefaultLeftMargin = 7.0;
+    private const double DefaultTopMargin = 3.0;
+    private const double ButtonSpacing = 20.0;
+
+    /// <summary>
+    /// Repositions the traffic light buttons with the specified offset from default positions.
+    /// </summary>
+    /// <param name="nsWindowHandle">The native NSWindow handle.</param>
+    /// <param name="offset">The offset (X moves right, Y moves down).</param>
+    public static void SetTrafficLightOffset(IntPtr nsWindowHandle, Point offset)
+    {
+        if (nsWindowHandle == IntPtr.Zero) return;
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) return;
+
+        try
+        {
+            RepositionButton(nsWindowHandle, NSWindowButton.Close, 0, offset);
+            RepositionButton(nsWindowHandle, NSWindowButton.Miniaturize, 1, offset);
+            RepositionButton(nsWindowHandle, NSWindowButton.Zoom, 2, offset);
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    private static void RepositionButton(IntPtr nsWindowHandle, NSWindowButton buttonType, int buttonIndex, Point offset)
+    {
+        var button = ObjCRuntime.SendMessage(
+            nsWindowHandle,
+            ObjCRuntime.StandardWindowButtonSelector,
+            (int)buttonType);
+
+        if (button == IntPtr.Zero) return;
+
+        var superview = ObjCRuntime.SendMessage(button, ObjCRuntime.SuperviewSelector);
+        if (superview == IntPtr.Zero) return;
+
+        var superviewFrame = ObjCRuntime.SendMessageCGRect(superview, ObjCRuntime.FrameSelector);
+        var buttonFrame = ObjCRuntime.SendMessageCGRect(button, ObjCRuntime.FrameSelector);
+        var defaultX = DefaultLeftMargin + (buttonIndex * ButtonSpacing);
+        var defaultY = superviewFrame.Height - DefaultTopMargin - buttonFrame.Height;
+
+        var newX = defaultX + offset.X;
+        var newY = defaultY - offset.Y;
+
+        ObjCRuntime.SendMessage(button, ObjCRuntime.SetFrameOriginSelector, newX, newY);
+    }
+}

--- a/src/ShadUI/Utilities/OnScreenKeyboard.cs
+++ b/src/ShadUI/Utilities/OnScreenKeyboard.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Avalonia;
@@ -142,15 +143,21 @@ internal static class OnScreenKeyboard
         {
             if ((uint)e.HResult == 0x80040154)
             {
-                Process p = new()
+                // Use fully qualified path to prevent command injection via PATH hijacking
+                var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.CommonProgramFiles);
+                var tabTipPath = Path.Combine(programFiles, "Microsoft Shared", "ink", "tabtip.exe");
+
+                if (File.Exists(tabTipPath))
                 {
-                    StartInfo = new ProcessStartInfo
+                    using var process = new Process();
+                    process.StartInfo = new ProcessStartInfo
                     {
-                        FileName = "tabtip.exe",
-                        UseShellExecute = true
-                    }
-                };
-                p.Start();
+                        FileName = tabTipPath,
+                        UseShellExecute = false,
+                        CreateNoWindow = true
+                    };
+                    process.Start();
+                }
             }
             else
             {

--- a/src/ShadUI/Utilities/OnScreenKeyboard.cs
+++ b/src/ShadUI/Utilities/OnScreenKeyboard.cs
@@ -57,6 +57,25 @@ internal static class OnScreenKeyboard
             handledEventsToo: true);
     }
 
+    /// <summary>
+    /// Cleans up static resources. Call this method during application shutdown.
+    /// </summary>
+    public static void Cleanup()
+    {
+        lock (LockObject)
+        {
+            if (_throttleTimer != null)
+            {
+                _throttleTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                _throttleTimer.Dispose();
+                _throttleTimer = null;
+            }
+
+            TopLevelMap.Clear();
+            _alreadyDone = false;
+        }
+    }
+
     private static void QueueKeyboardEvent(TextBox textBox, bool state)
     {
         lock (LockObject)

--- a/src/ShadUI/Utilities/SmoothScrollController.cs
+++ b/src/ShadUI/Utilities/SmoothScrollController.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Rendering;
+using Avalonia.VisualTree;
+
+// ReSharper disable once CheckNamespace
+namespace ShadUI;
+
+internal sealed class SmoothScrollController
+{
+	readonly ScrollViewer instance;
+    IRenderRoot? visualRoot;
+	TopLevel? topLevel;
+    
+	double targetX, currentX;
+	double targetY, currentY;
+    
+	bool isLoopRunning;
+	TimeSpan lastFrameTime = TimeSpan.Zero;
+
+    public SmoothScrollController(
+        ScrollViewer instance,
+        double baseStepSize,
+        double smoothingFactor)
+    {
+        this.instance = instance;
+        
+        BaseStepSize = baseStepSize;
+        SmoothingFactor = smoothingFactor;
+        
+        instance.AddHandler(InputElement.PointerWheelChangedEvent, OnPointerWheelChanged, RoutingStrategies.Tunnel);
+    }
+
+    public void Stop()
+    {
+        instance.RemoveHandler(InputElement.PointerWheelChangedEvent, OnPointerWheelChanged);
+        
+        isLoopRunning = false;
+        lastFrameTime = TimeSpan.Zero;
+		
+        topLevel = null;
+
+        targetY = 0;
+        currentY = 0;
+		
+        targetX = 0;
+        currentX = 0;
+    }
+
+    
+    public double BaseStepSize { get; set; }
+	
+    public double SmoothingFactor { get; set; }
+
+
+    void OnPointerWheelChanged(
+        object? sender,
+        PointerWheelEventArgs e)
+    {
+        if (e.Handled)
+            return;
+        
+        topLevel ??= TopLevel.GetTopLevel(instance);
+        if (topLevel is null)
+            return;
+        
+        // Prevent scroll direction leaks
+        double dx = e.Delta.X;
+        double dy = e.Delta.Y;
+        
+        if (Math.Abs(dy) > Math.Abs(dx))
+            dx = 0;
+        else if (Math.Abs(dx) > Math.Abs(dy))
+            dy = 0;
+
+        // Check if this event is actually for us
+        Visual? source = e.Source as Visual;
+        
+        //  Flyouts
+        IRenderRoot? sourceRoot = source?.GetVisualRoot();
+        visualRoot ??= instance.GetVisualRoot();
+
+        if (sourceRoot != visualRoot)
+            return; // this event is from a popup/flyout. TRAP IT!!! >:)
+
+        //  Chaining
+        bool isShiftPressed = (e.KeyModifiers & KeyModifiers.Shift) != 0;
+        while (source is not null && source != instance)
+        {
+            if (source is ScrollViewer inner && inner.IsVisible)
+            {
+                bool innerHasHorizontal = inner.HorizontalScrollBarVisibility != ScrollBarVisibility.Disabled;
+                bool innerHasVertical = inner.VerticalScrollBarVisibility != ScrollBarVisibility.Disabled;
+
+                double tryingToMoveX = dx + (isShiftPressed ? dy : 0);
+                double tryingToMoveY = isShiftPressed ? 0 : dy;
+                
+                if (innerHasHorizontal && !innerHasVertical && !isShiftPressed)
+                {
+                    tryingToMoveX += tryingToMoveY;
+                    tryingToMoveY = 0;
+                }
+                
+                bool canMoveX = (tryingToMoveX > 0 && inner.Offset.X > 0) || (tryingToMoveX < 0 && inner.Offset.X < (inner.Extent.Width - inner.Viewport.Width));
+                bool canMoveY = (tryingToMoveY > 0 && inner.Offset.Y > 0) || (tryingToMoveY < 0 && inner.Offset.Y < (inner.Extent.Height - inner.Viewport.Height));
+                
+                if (canMoveX || canMoveY)
+                    return; // Trap it! The inner child can handle this movement itself
+            }
+
+            source = source.GetVisualParent();
+        }
+        
+        // Sync current position if we were idle
+        if (!isLoopRunning)
+        {
+            currentX = instance.Offset.X;
+            currentY = instance.Offset.Y;
+            targetX = currentX;
+            targetY = currentY;
+        }
+
+        // Updating target
+        bool hasHorizontal = instance.HorizontalScrollBarVisibility != ScrollBarVisibility.Disabled;
+        bool hasVertical = instance.VerticalScrollBarVisibility != ScrollBarVisibility.Disabled;
+        
+        if (Math.Abs(dx) > 0) 
+        {
+            targetX -= dx * BaseStepSize;
+            targetY -= dy * BaseStepSize;
+        }
+        else if (isShiftPressed || (hasHorizontal && !hasVertical))
+        {
+            targetX -= dy * BaseStepSize;
+        }
+        else
+        {
+            targetY -= dy * BaseStepSize;
+        }
+        
+        StartAnimationLoop();
+        e.Handled = true;
+    }
+
+    
+    void StartAnimationLoop()
+    {
+        if (isLoopRunning || topLevel is null)
+            return;
+        
+        isLoopRunning = true;
+        topLevel.RequestAnimationFrame(time =>
+        {
+            lastFrameTime = time;
+            OnFrameTick(time);
+        });
+    }
+
+    void OnFrameTick(
+        TimeSpan time)
+    {
+        if (!isLoopRunning || topLevel is null)
+            return;
+
+        double dt = (time - lastFrameTime).TotalSeconds;
+        lastFrameTime = time;
+
+        // Clamp target (doing it in frame tick and not before in case content resizes mid-scroll)
+        targetX = Math.Clamp(targetX,
+            min: 0,
+            max: Math.Max(instance.Extent.Width - instance.Viewport.Width, 0));
+        targetY = Math.Clamp(targetY,
+            min: 0,
+            max: Math.Max(instance.Extent.Height - instance.Viewport.Height, 0));
+        
+        // Calculate positions
+        double dx = targetX - currentX;
+        double dy = targetY - currentY;
+        
+        if (Math.Abs(dx) < 0.1 && Math.Abs(dy) < 0.1) // stop if too small
+        {
+            instance.Offset = new(targetX, targetY);
+            isLoopRunning = false;
+
+            return;
+        }
+
+        double factor = 1.0 - Math.Exp(-SmoothingFactor * dt);
+        currentX += dx * factor;
+        currentY += dy * factor;
+        
+        // Update positions
+        instance.Offset = new(currentX, currentY);
+        topLevel.RequestAnimationFrame(OnFrameTick);
+    }
+}


### PR DESCRIPTION
Add a MarqueeTextBlock control:

- Allows you to create a scrolling TextBlock that adjusts to the width of the element
- If the element's IsVisible property is set to false, the animation does not play
- The element also adapts to ShadUI styles (Classes)

**Sample Work**
<img width="944" height="230" alt="marquee" src="https://github.com/user-attachments/assets/d731763b-c492-4b69-bbb1-6d65a434bde8" />

I added an element to the Typography ShadUI.Demo section. If necessary, I can move it to another ViewModel