### PR TITLE
Avalonia 12 Support

### DIFF
--- a/src/ShadUI.Demo/App.axaml.cs
+++ b/src/ShadUI.Demo/App.axaml.cs
@@ -29,7 +29,6 @@ public class App : Application
             return;
         }
 
-        DisableAvaloniaDataAnnotationValidation();
         var provider = new ServiceProvider().RegisterDialogs();
 
         var themeWatcher = provider.GetService<ThemeWatcher>();
@@ -42,15 +41,5 @@ public class App : Application
 
         desktop.MainWindow = mainWindow;
         base.OnFrameworkInitializationCompleted();
-    }
-
-    private void DisableAvaloniaDataAnnotationValidation()
-    {
-        // Get an array of plugins to remove
-        var dataValidationPluginsToRemove =
-            BindingPlugins.DataValidators.OfType<DataAnnotationsValidationPlugin>().ToArray();
-
-        // remove each entry found
-        foreach (var plugin in dataValidationPluginsToRemove) BindingPlugins.DataValidators.Remove(plugin);
     }
 }

--- a/src/ShadUI.Demo/Controls/CodeTextBlock.axaml.cs
+++ b/src/ShadUI.Demo/Controls/CodeTextBlock.axaml.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Controls.Documents;
 using Avalonia.Controls.Primitives;
+using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Metadata;

--- a/src/ShadUI.Demo/Program.cs
+++ b/src/ShadUI.Demo/Program.cs
@@ -1,6 +1,9 @@
 ﻿using System;
 using Avalonia;
+using LiveChartsCore;
+using LiveChartsCore.SkiaSharpView;
 using Serilog;
+using SkiaSharp;
 
 namespace ShadUI.Demo;
 
@@ -14,6 +17,12 @@ internal sealed class Program
     {
         try
         {
+            LiveCharts.Configure(config =>
+                config.HasTextSettings(new TextSettings
+                {
+                    DefaultTypeface = SKTypeface.FromFamilyName("Segoe UI") ?? SKTypeface.Default
+                }));
+
             BuildAvaloniaApp()
                 .StartWithClassicDesktopLifetime(args);
         }
@@ -31,6 +40,7 @@ internal sealed class Program
     {
         return AppBuilder.Configure<App>()
             .UsePlatformDetect()
+            .UseHarfBuzz()
             .LogToTrace();
     }
 }

--- a/src/ShadUI.Demo/ShadUI.Demo.csproj
+++ b/src/ShadUI.Demo/ShadUI.Demo.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>WinExe</OutputType>
-        <TargetFrameworks>net9.0; net10.0</TargetFrameworks>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <Version>1.1.1</Version>
         <AssemblyName>shadui-app</AssemblyName>
@@ -23,22 +23,19 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.3.10" />
-        <PackageReference Include="Avalonia.AvaloniaEdit" Version="11.3.0"/>
-        <PackageReference Include="Avalonia.Desktop" Version="11.3.10" />
-        <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-        <PackageReference Include="Avalonia.Diagnostics" Version="11.3.10">
-            <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
-            <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="AvaloniaEdit.TextMate" Version="11.3.0"/>
-        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0"/>
-        <PackageReference Include="HotAvalonia" Version="3.0.2" PrivateAssets="All" />
-        <PackageReference Include="Jab" Version="0.12.0" PrivateAssets="All" />
-        <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.0.0-rc5.4"/>
+        <PackageReference Include="Avalonia" Version="12.0.2"/>
+        <PackageReference Include="Avalonia.AvaloniaEdit" Version="12.0.0"/>
+        <PackageReference Include="Avalonia.Desktop" Version="12.0.2"/>
+        <PackageReference Include="Avalonia.HarfBuzz" Version="12.0.2"/>
+        <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1"/>
+        <PackageReference Include="AvaloniaEdit.TextMate" Version="12.0.0"/>
+        <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2"/>
+        <PackageReference Include="HotAvalonia" Version="3.1.0" PrivateAssets="All" />
+        <PackageReference Include="Jab" Version="0.12.0" PrivateAssets="All"/>
+        <PackageReference Include="LiveChartsCore.SkiaSharpView.Avalonia" Version="2.1.0-dev-365" />
         <PackageReference Include="Serilog" Version="4.3.0"/>
         <PackageReference Include="Serilog.Sinks.File" Version="7.0.0"/>
-        <PackageReference Include="TextMateSharp.Grammars" Version="1.0.70" />
+        <PackageReference Include="TextMateSharp.Grammars" Version="2.0.3" />
     </ItemGroup>
 
     <ItemGroup>
@@ -46,10 +43,10 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Compile Update="Views\SmoothScrollPage.axaml.cs">
-        <DependentUpon>SmoothScrollPage.axaml</DependentUpon>
-        <SubType>Code</SubType>
-      </Compile>
+        <Compile Update="Views\SmoothScrollPage.axaml.cs">
+            <DependentUpon>SmoothScrollPage.axaml</DependentUpon>
+            <SubType>Code</SubType>
+        </Compile>
     </ItemGroup>
 
     <Target Name="GenerateXamlTextCopies" BeforeTargets="PrepareForRun">

--- a/src/ShadUI.Demo/ViewModels/DashboardViewModel.cs
+++ b/src/ShadUI.Demo/ViewModels/DashboardViewModel.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using Avalonia.Media;
-using Avalonia.Platform;
-using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using LiveChartsCore;
 using LiveChartsCore.SkiaSharpView;
@@ -16,10 +14,10 @@ public sealed partial class DashboardViewModel : ViewModelBase, INavigable
     private readonly PageManager _pageManager;
     public ThemeWatcher ThemeWatcher { get; }
 
-    private readonly SKTypeface _typeface;
+    private readonly SolidColorPaint _xAxisLabelsPaint = new() { Color = SKColors.Gray };
+    private readonly SolidColorPaint _yAxisLabelsPaint = new() { Color = SKColors.Gray };
 
-    [ObservableProperty]
-    private static SolidColorPaint _tooltipTextPaint = null!;
+    public static SolidColorPaint TooltipTextPaint { get; } = new() { Color = SKColors.Black };
 
     public DashboardViewModel(PageManager pageManager, ThemeWatcher themeWatcher)
     {
@@ -31,24 +29,12 @@ public sealed partial class DashboardViewModel : ViewModelBase, INavigable
             UpdateSeriesFill(colors.PrimaryColor);
         };
 
-        var fontUri = new Uri("avares://shadui-app/Assets/Fonts/Manrope-Regular.ttf");
-        var fontAsset = AssetLoader.Open(fontUri);
-
-        using var skData = SKData.Create(fontAsset);
-        _typeface = SKTypeface.FromData(skData);
-
-        _tooltipTextPaint = new SolidColorPaint
-        {
-            Color = SKColors.Black,
-            SKTypeface = _typeface
-        };
-
         XAxes =
         [
             new Axis
             {
                 Labels = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
-                LabelsPaint = new SolidColorPaint { Color = SKColors.Gray, SKTypeface = _typeface },
+                LabelsPaint = _xAxisLabelsPaint,
                 TextSize = 12,
                 MinStep = 1
             }
@@ -59,7 +45,7 @@ public sealed partial class DashboardViewModel : ViewModelBase, INavigable
             new Axis
             {
                 Labeler = Labelers.Currency,
-                LabelsPaint = new SolidColorPaint { Color = SKColors.Gray, SKTypeface = _typeface },
+                LabelsPaint = _yAxisLabelsPaint,
                 TextSize = 12,
                 MinStep = 1500,
                 ShowSeparatorLines = false
@@ -87,14 +73,8 @@ public sealed partial class DashboardViewModel : ViewModelBase, INavigable
             colors.ForegroundColor.B,
             colors.ForegroundColor.A);
 
-        var foregroundPaint = new SolidColorPaint
-        {
-            Color = foreground,
-            SKTypeface = _typeface
-        };
-
-        XAxes[0].LabelsPaint = foregroundPaint;
-        YAxes[0].LabelsPaint = foregroundPaint;
+        _xAxisLabelsPaint.Color = foreground;
+        _yAxisLabelsPaint.Color = foreground;
     }
 
     public ISeries[] Series { get; set; } =

--- a/src/ShadUI.Demo/Views/CardPage.axaml
+++ b/src/ShadUI.Demo/Views/CardPage.axaml
@@ -66,7 +66,7 @@
                             </StackPanel>
                         </shadui:Card.Header>
                         <StackPanel Spacing="16">
-                            <TextBox Watermark="Name of your project" shadui:ControlAssist.Label="Name" />
+                            <TextBox PlaceholderText="Name of your project" shadui:ControlAssist.Label="Name" />
                             <ComboBox
                                 SelectedIndex="0"
                                 Width="300"

--- a/src/ShadUI.Demo/Views/Examples/DataTable/BasicDataTableContent.axaml
+++ b/src/ShadUI.Demo/Views/Examples/DataTable/BasicDataTableContent.axaml
@@ -20,7 +20,7 @@
                     Classes="Clearable"
                     HorizontalAlignment="Left"
                     Text="{Binding SearchString, Mode=TwoWay}"
-                    Watermark="Filter emails..."
+                    PlaceholderText="Filter emails..."
                     Width="384"
                     shadui:ControlAssist.ShowProgress="{Binding IsSearching}">
                     <TextBox.InnerRightContent>

--- a/src/ShadUI.Demo/Views/Examples/Input/FormInputContent.axaml
+++ b/src/ShadUI.Demo/Views/Examples/Input/FormInputContent.axaml
@@ -24,20 +24,20 @@
             <TextBox
                 Classes="Clearable"
                 Text="{Binding Email, Mode=TwoWay}"
-                Watermark="user@example.com"
+                PlaceholderText="user@example.com"
                 shadui:ControlAssist.Hint="This is your public display name."
                 shadui:ControlAssist.Label="Email" />
             <TextBox
                 Classes="PasswordReveal"
                 PasswordChar="•"
                 Text="{Binding Password, Mode=TwoWay}"
-                Watermark="Enter password"
+                PlaceholderText="Enter password"
                 shadui:ControlAssist.Label="Password" />
             <TextBox
                 Classes="PasswordReveal"
                 PasswordChar="•"
                 Text="{Binding ConfirmPassword, Mode=TwoWay}"
-                Watermark="Confirm password"
+                PlaceholderText="Confirm password"
                 shadui:ControlAssist.Label="Confirm" />
         </StackPanel>
         <shadui:Card.Footer>

--- a/src/ShadUI.Demo/Views/Examples/Numeric/FormNumericContent.axaml
+++ b/src/ShadUI.Demo/Views/Examples/Numeric/FormNumericContent.axaml
@@ -24,7 +24,7 @@
             <NumericUpDown
                 FormatString="N0"
                 Value="{Binding Age, Mode=TwoWay}"
-                Watermark="Enter your age"
+                PlaceholderText="Enter your age"
                 shadui:ControlAssist.Hint="You must be at least 18 years old."
                 shadui:ControlAssist.Label="Age" />
         </StackPanel>

--- a/src/ShadUI.Demo/Views/InputPage.axaml
+++ b/src/ShadUI.Demo/Views/InputPage.axaml
@@ -56,26 +56,26 @@
                 Spacing="32">
                 <controls:ControlBlock Title="Default" Xaml="{Binding DefaultInputCode}">
                     <StackPanel>
-                        <TextBox Watermark="Email" Width="225" />
+                        <TextBox PlaceholderText="Email" Width="225" />
                     </StackPanel>
                 </controls:ControlBlock>
                 <controls:ControlBlock Title="Disabled" Xaml="{Binding DisabledCode}">
                     <TextBox
                         IsEnabled="False"
-                        Watermark="Email"
+                        PlaceholderText="Email"
                         Width="225" />
                 </controls:ControlBlock>
                 <controls:ControlBlock Title="With Label" Xaml="{Binding WithLabelCode}">
                     <TextBox
                         Classes="Clearable"
-                        UseFloatingWatermark="True"
-                        Watermark="Email"
+                        UseFloatingPlaceholder="True"
+                        PlaceholderText="Email"
                         Width="225" />
                 </controls:ControlBlock>
                 <controls:ControlBlock Title="With Custom Label" Xaml="{Binding WithCustomLabelCode}">
                     <TextBox
                         Classes="Clearable"
-                        Watermark="user@example.com"
+                        PlaceholderText="user@example.com"
                         Width="225"
                         shadui:ControlAssist.Label="Email" />
                 </controls:ControlBlock>
@@ -83,7 +83,7 @@
                     <TextBox
                         Classes="Clearable"
                         Text="{Binding SearchString, Mode=TwoWay}"
-                        Watermark="Search here..."
+                        PlaceholderText="Search here..."
                         Width="225"
                         shadui:ControlAssist.ShowProgress="{Binding IsSearching}">
                         <TextBox.InnerRightContent>
@@ -99,7 +99,7 @@
                         Classes="Clearable"
                         FilterMode="Contains"
                         ItemsSource="{Binding WebFrameworks}"
-                        Watermark="Search here..."
+                        PlaceholderText="Search here..."
                         Width="225"
                         shadui:ControlAssist.Hint="Your favorite web framework"
                         shadui:ControlAssist.Label="Search a framework"
@@ -115,7 +115,7 @@
                 <controls:ControlBlock Title="Text Area" Xaml="{Binding TextAreaCode}">
                     <TextBox
                         AcceptsReturn="True"
-                        Watermark="Enter a long description here..."
+                        PlaceholderText="Enter a long description here..."
                         Width="225"
                         shadui:ControlAssist.Height="300"
                         shadui:ControlAssist.Label="Description" />

--- a/src/ShadUI.Demo/Views/LoginContent.axaml
+++ b/src/ShadUI.Demo/Views/LoginContent.axaml
@@ -16,14 +16,14 @@
         <TextBox
             Classes="Clearable"
             Text="{Binding Email, Mode=TwoWay}"
-            Watermark="user@example.com"
+            PlaceholderText="user@example.com"
             shadui:ControlAssist.Label="Email"
             shadui:ElementAssist.FocusOnLoad="True" />
         <TextBox
             Classes="PasswordReveal"
             PasswordChar="•"
             Text="{Binding Password, Mode=TwoWay}"
-            Watermark="Enter password"
+            PlaceholderText="Enter password"
             shadui:ControlAssist.Label="Password" />
         <StackPanel Margin="0,24,0,0" Spacing="16">
             <Button

--- a/src/ShadUI.Demo/Views/NumericPage.axaml
+++ b/src/ShadUI.Demo/Views/NumericPage.axaml
@@ -71,7 +71,7 @@
                 </controls:ControlBlock>
                 <controls:ControlBlock Title="With Label" Xaml="{Binding WithLabelCode}">
                     <NumericUpDown
-                        Watermark="Enter quantity"
+                        PlaceholderText="Enter quantity"
                         Width="225"
                         shadui:ControlAssist.Label="Quantity" />
                 </controls:ControlBlock>
@@ -80,7 +80,7 @@
                         Classes="Clearable"
                         FormatString="N2"
                         ShowButtonSpinner="False"
-                        Watermark="0.00"
+                        PlaceholderText="0.00"
                         Width="225"
                         shadui:ControlAssist.Hint="Enter the product price"
                         shadui:ControlAssist.Label="Price">

--- a/src/ShadUI/AttachedProperties/ControlAssist.cs
+++ b/src/ShadUI/AttachedProperties/ControlAssist.cs
@@ -19,7 +19,7 @@ public static class ControlAssist
                 var label = eventArgs.NameScope.Find<TextBlock>("PART_Label");
                 if (label is null || string.IsNullOrEmpty(args.NewValue?.ToString())) return;
 
-                if (sender is TextBox tb) tb.UseFloatingWatermark = true;
+                if (sender is TextBox tb) tb.UseFloatingPlaceholder = true;
 
                 label.Text = args.NewValue!.ToString();
             };

--- a/src/ShadUI/AttachedProperties/ElementAssist.cs
+++ b/src/ShadUI/AttachedProperties/ElementAssist.cs
@@ -172,7 +172,7 @@ public class ElementAssist
             parent.Tag = "inactive";
         }
 
-        void HandleGotFocus(object? sender, GotFocusEventArgs args)
+        void HandleGotFocus(object? sender, FocusChangedEventArgs args)
         {
             parent.Tag = "active";
         }
@@ -197,7 +197,7 @@ public class ElementAssist
     private class FocusHandlers
     {
         public Control? Child { get; set; }
-        public EventHandler<GotFocusEventArgs>? GotFocusHandler { get; set; }
+        public EventHandler<FocusChangedEventArgs>? GotFocusHandler { get; set; }
         public EventHandler<RoutedEventArgs>? LostFocusHandler { get; set; }
     }
 

--- a/src/ShadUI/Controls/AutoCompleteBox/AutoCompleteBox.axaml
+++ b/src/ShadUI/Controls/AutoCompleteBox/AutoCompleteBox.axaml
@@ -10,7 +10,7 @@
             Spacing="8"
             Width="225">
             <AutoCompleteBox
-                Watermark="Search here..."
+                PlaceholderText="Search here..."
                 Width="225"
                 shadui:ControlAssist.Hint="This is test"
                 shadui:ControlAssist.Label="Search">
@@ -23,7 +23,7 @@
             </AutoCompleteBox>
             <AutoCompleteBox
                 Text="xxx"
-                Watermark="Search here..."
+                PlaceholderText="Search here..."
                 Width="225"
                 shadui:ControlAssist.Hint="This is test"
                 shadui:ControlAssist.Label="Search"
@@ -36,7 +36,7 @@
                 </AutoCompleteBox.InnerRightContent>
             </AutoCompleteBox>
             <AutoCompleteBox
-                Watermark="Search here..."
+                PlaceholderText="Search here..."
                 Width="225"
                 shadui:ControlAssist.Hint="This is test"
                 shadui:ControlAssist.Label="Search"
@@ -171,7 +171,7 @@
                                                             Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
                                 Margin="0,0,0,6"
                                 Name="Label"
-                                Text="{TemplateBinding Watermark}" />
+                                Text="{TemplateBinding PlaceholderText}" />
                             <TextBox
                                 Background="{TemplateBinding Background}"
                                 BorderBrush="{TemplateBinding BorderBrush}"
@@ -187,7 +187,7 @@
                                 InnerRightContent="{TemplateBinding InnerRightContent}"
                                 Name="PART_TextBox"
                                 Padding="{TemplateBinding Padding}"
-                                Watermark="{TemplateBinding Watermark}"
+                                PlaceholderText="{TemplateBinding PlaceholderText}"
                                 shadui:ControlAssist.MinHeight="{TemplateBinding shadui:ControlAssist.MinHeight}"
                                 shadui:ControlAssist.ShowProgress="{TemplateBinding shadui:ControlAssist.ShowProgress}"
                                 shadui:ElementAssist.Classes="{TemplateBinding shadui:ElementAssist.Classes}" />

--- a/src/ShadUI/Controls/Breakpoint/BreakpointView.axaml
+++ b/src/ShadUI/Controls/Breakpoint/BreakpointView.axaml
@@ -6,9 +6,9 @@
         <Setter Property="IsVisible">
             <Setter.Value>
                 <MultiBinding Converter="{x:Static shadui:WidthToVisibilityConverter.Instance}">
-                    <CompiledBinding Path="Bounds.Width" RelativeSource="{RelativeSource AncestorType={x:Type shadui:BreakpointViewPort}}" />
-                    <CompiledBinding Path="Breakpoint" RelativeSource="{RelativeSource Self}" />
-                    <CompiledBinding Path="Invert" RelativeSource="{RelativeSource Self}" />
+                    <Binding Path="$parent[shadui:BreakpointViewPort].Bounds.Width" />
+                    <Binding Path="$self.Breakpoint" />
+                    <Binding Path="$self.Invert" />
                 </MultiBinding>
             </Setter.Value>
         </Setter>

--- a/src/ShadUI/Controls/Calendar/CalendarDatePicker.axaml
+++ b/src/ShadUI/Controls/Calendar/CalendarDatePicker.axaml
@@ -73,22 +73,18 @@
                                     <TextBlock
                                         HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                         Margin="{TemplateBinding Padding}"
-                                        Name="watermark"
+                                        Name="Placeholder"
                                         Opacity="0.5"
-                                        Text="{TemplateBinding Watermark}"
+                                        Text="{TemplateBinding PlaceholderText}"
                                         TextAlignment="{TemplateBinding TextAlignment}"
                                         TextWrapping="{TemplateBinding TextWrapping}"
                                         VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                         <TextBlock.IsVisible>
                                             <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                                <CompiledBinding
-                                                    Converter="{x:Static StringConverters.IsNullOrEmpty}"
-                                                    ElementName="PART_TextPresenter"
-                                                    Path="PreeditText" />
-                                                <CompiledBinding
-                                                    Converter="{x:Static StringConverters.IsNullOrEmpty}"
-                                                    Path="Text"
-                                                    RelativeSource="{RelativeSource TemplatedParent}" />
+                                                <Binding Path="#PART_TextPresenter.PreeditText"
+                                                         Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                                                <Binding Path="$parent[TextBox].Text"
+                                                         Converter="{x:Static StringConverters.IsNullOrEmpty}" />
                                             </MultiBinding>
                                         </TextBlock.IsVisible>
                                     </TextBlock>
@@ -158,7 +154,7 @@
         <Setter Property="FontSize" Value="14" />
         <Setter Property="Padding" Value="12,4" />
         <Setter Property="FontWeight" Value="Medium" />
-        <Setter Property="Watermark" Value="Pick a date" />
+        <Setter Property="PlaceholderText" Value="Pick a date" />
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
         <Setter Property="Template">
             <ControlTemplate>
@@ -198,8 +194,8 @@
                                 Name="PART_TextBox"
                                 Padding="{TemplateBinding Padding}"
                                 Theme="{StaticResource InnerTextBoxTheme}"
-                                UseFloatingWatermark="False"
-                                Watermark="{TemplateBinding Watermark}" />
+                                UseFloatingPlaceholder="False"
+                                PlaceholderText="{TemplateBinding PlaceholderText}" />
                             <Border
                                 Background="Transparent"
                                 CornerRadius="{TemplateBinding CornerRadius}"

--- a/src/ShadUI/Controls/Common.axaml
+++ b/src/ShadUI/Controls/Common.axaml
@@ -58,22 +58,18 @@
                         <Panel Name="PART_TextContainer">
                             <TextBlock
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                Name="watermark"
+                                Name="Placeholder"
                                 Opacity="0.5"
-                                Text="{TemplateBinding Watermark}"
+                                Text="{TemplateBinding PlaceholderText}"
                                 TextAlignment="{TemplateBinding TextAlignment}"
                                 TextWrapping="{TemplateBinding TextWrapping}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <TextBlock.IsVisible>
                                     <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                        <CompiledBinding
-                                            Converter="{x:Static StringConverters.IsNullOrEmpty}"
-                                            ElementName="PART_TextPresenter"
-                                            Path="PreeditText" />
-                                        <CompiledBinding
-                                            Converter="{x:Static StringConverters.IsNullOrEmpty}"
-                                            Path="Text"
-                                            RelativeSource="{RelativeSource TemplatedParent}" />
+                                        <Binding Path="#PART_TextPresenter.PreeditText"
+                                                 Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                                        <Binding Path="$parent[TextBox].Text"
+                                                 Converter="{x:Static StringConverters.IsNullOrEmpty}" />
                                     </MultiBinding>
                                 </TextBlock.IsVisible>
                             </TextBlock>

--- a/src/ShadUI/Controls/DateInput/DateInput.axaml
+++ b/src/ShadUI/Controls/DateInput/DateInput.axaml
@@ -64,7 +64,7 @@
                                         Text="{TemplateBinding MonthString,
                                                                Mode=TwoWay}"
                                         Theme="{StaticResource InputBoxTheme}"
-                                        Watermark="mm"
+                                        PlaceholderText="mm"
                                         shadui:ElementAssist.FocusOnLoad="{TemplateBinding shadui:ElementAssist.FocusOnLoad}" />
                                     <TextBlock
                                         FontSize="18"
@@ -82,7 +82,7 @@
                                         Text="{TemplateBinding DayString,
                                                                Mode=TwoWay}"
                                         Theme="{StaticResource InputBoxTheme}"
-                                        Watermark="dd" />
+                                        PlaceholderText="dd" />
                                     <TextBlock
                                         FontSize="18"
                                         Grid.Column="3"
@@ -99,7 +99,7 @@
                                         Text="{TemplateBinding YearString,
                                                                Mode=TwoWay}"
                                         Theme="{StaticResource InputBoxTheme}"
-                                        Watermark="yyyy" />
+                                        PlaceholderText="yyyy" />
                                 </Grid>
                             </Border>
                             <TextBlock

--- a/src/ShadUI/Controls/DateInput/DateInput.axaml.cs
+++ b/src/ShadUI/Controls/DateInput/DateInput.axaml.cs
@@ -129,7 +129,7 @@ public class DateInput : TemplatedControl
 
     private bool _updating;
 
-    private void OnInputChanged(object sender, TextChangedEventArgs e)
+    private void OnInputChanged(object? sender, TextChangedEventArgs e)
     {
         if (sender is not TextBox textBox) return;
 
@@ -149,7 +149,7 @@ public class DateInput : TemplatedControl
         nextTextBox.SelectAll();
     }
 
-    private void OnTextBoxLostFocus(object sender, RoutedEventArgs e)
+    private void OnTextBoxLostFocus(object? sender, RoutedEventArgs e)
     {
         InputFocus = false;
 

--- a/src/ShadUI/Controls/Dialog/DialogHost.axaml.cs
+++ b/src/ShadUI/Controls/Dialog/DialogHost.axaml.cs
@@ -22,6 +22,7 @@ namespace ShadUI;
 public class DialogHost : TemplatedControl, IDisposable
 {
     private bool _disposed;
+
     /// <summary>
     ///     Defines the <see cref="Owner" /> property.
     /// </summary>
@@ -259,7 +260,7 @@ public class DialogHost : TemplatedControl, IDisposable
         manager.AllowDismissChanged -= AllowDismissChanged;
     }
 
-    private void ManagerOnDialogShown(object sender, DialogShownEventArgs e)
+    private void ManagerOnDialogShown(object? sender, DialogShownEventArgs e)
     {
         if (Manager is null || Owner is null) return;
 
@@ -274,7 +275,7 @@ public class DialogHost : TemplatedControl, IDisposable
         Owner.HasOpenDialog = true;
     }
 
-    private async void ManagerOnDialogClosed(object sender, DialogClosedEventArgs e)
+    private async void ManagerOnDialogClosed(object? sender, DialogClosedEventArgs e)
     {
         try
         {
@@ -296,7 +297,7 @@ public class DialogHost : TemplatedControl, IDisposable
         }
     }
 
-    private void AllowDismissChanged(object sender, bool e)
+    private void AllowDismissChanged(object? sender, bool e)
     {
         if (Manager is null || Manager.Dialogs.Count == 0) return;
 

--- a/src/ShadUI/Controls/NumericUpDown/NumericUpDown.axaml
+++ b/src/ShadUI/Controls/NumericUpDown/NumericUpDown.axaml
@@ -39,22 +39,18 @@
                             <TextBlock
                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                 Margin="{TemplateBinding Padding}"
-                                Name="Watermark"
+                                Name="Placeholder"
                                 Opacity="0.5"
-                                Text="{TemplateBinding Watermark}"
+                                Text="{TemplateBinding PlaceholderText}"
                                 TextAlignment="{TemplateBinding TextAlignment}"
                                 TextWrapping="{TemplateBinding TextWrapping}"
                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                 <TextBlock.IsVisible>
                                     <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                        <CompiledBinding
-                                            Converter="{x:Static StringConverters.IsNullOrEmpty}"
-                                            ElementName="PART_TextPresenter"
-                                            Path="PreeditText" />
-                                        <CompiledBinding
-                                            Converter="{x:Static StringConverters.IsNullOrEmpty}"
-                                            Path="Text"
-                                            RelativeSource="{RelativeSource TemplatedParent}" />
+                                        <Binding Path="#PART_TextPresenter.PreeditText"
+                                                 Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                                        <Binding Path="$parent[TextBox].Text"
+                                                 Converter="{x:Static StringConverters.IsNullOrEmpty}" />
                                     </MultiBinding>
                                 </TextBlock.IsVisible>
                             </TextBlock>
@@ -169,7 +165,7 @@
                                     TextWrapping="NoWrap"
                                     Theme="{StaticResource InnerTextBoxTheme}"
                                     VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                    Watermark="{TemplateBinding Watermark}" />
+                                    PlaceholderText="{TemplateBinding PlaceholderText}" />
                             </ButtonSpinner>
                             <TextBlock
                                 Classes="Caption Muted"

--- a/src/ShadUI/Controls/ScrollViewer/ScrollBarStyles.axaml
+++ b/src/ShadUI/Controls/ScrollViewer/ScrollBarStyles.axaml
@@ -75,8 +75,8 @@
                         Name="PART_PageUpButton">
                         <RepeatButton.IsVisible>
                             <MultiBinding Converter="{x:Static shadui:SidebarScrollerToVisibilityBool.Up}">
-                                <CompiledBinding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
-                                <CompiledBinding Path="Minimum" RelativeSource="{RelativeSource TemplatedParent}" />
+                                <Binding Path="$parent[ScrollBar].Value" />
+                                <Binding Path="$parent[ScrollBar].Minimum" />
                             </MultiBinding>
                         </RepeatButton.IsVisible>
                         <PathIcon
@@ -99,8 +99,8 @@
                         Name="PART_PageDownButton">
                         <RepeatButton.IsVisible>
                             <MultiBinding Converter="{x:Static shadui:SidebarScrollerToVisibilityBool.Down}">
-                                <CompiledBinding Path="Value" RelativeSource="{RelativeSource TemplatedParent}" />
-                                <CompiledBinding Path="Maximum" RelativeSource="{RelativeSource TemplatedParent}" />
+                                <Binding Path="$parent[ScrollBar].Value" />
+                                <Binding Path="$parent[ScrollBar].Maximum" />
                             </MultiBinding>
                         </RepeatButton.IsVisible>
                         <PathIcon

--- a/src/ShadUI/Controls/ScrollViewer/ScrollViewerStyles.axaml
+++ b/src/ShadUI/Controls/ScrollViewer/ScrollViewerStyles.axaml
@@ -3,7 +3,7 @@ is use for x:TypeArguments="system:Double" DO NOT REMOVE -->
 <Styles
     xmlns="https://github.com/avaloniaui"
     xmlns:shadui="clr-namespace:ShadUI"
-    xmlns:system="clr-namespace:System;assembly=netstandard"  
+    xmlns:system="clr-namespace:System;assembly=netstandard"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <Style Selector="ScrollViewer">
         <Setter Property="shadui:SmoothScrollAssist.IsEnabled" Value="True" />
@@ -11,7 +11,7 @@ is use for x:TypeArguments="system:Double" DO NOT REMOVE -->
                 Value="{OnPlatform 70.0, macOS=40.0, x:TypeArguments=system:Double}" />
         <Setter Property="shadui:SmoothScrollAssist.SmoothingFactor"
                 Value="{OnPlatform 20.0, macOS=50.0, x:TypeArguments=system:Double}" />
-		<Setter Property="Template">
+        <Setter Property="Template">
             <ControlTemplate>
                 <Panel>
                     <Panel Name="InnerPanel">
@@ -87,7 +87,7 @@ is use for x:TypeArguments="system:Double" DO NOT REMOVE -->
         </Style>
         <Style Selector="^ /template/ Panel#InnerPanel">
             <Setter Property="OpacityMask">
-                <MultiBinding Converter="{x:Static shadui:ScrollerToOpacityMask.Top}">
+                <MultiBinding Converter="{x:Static shadui:ScrollerToOpacityMask.Top}" x:CompileBindings="False">
                     <Binding Path="$parent[Panel].Children[2].Children[0].Value" />
                     <Binding Path="$parent[Panel].Children[2].Children[0].Minimum" />
                 </MultiBinding>
@@ -95,7 +95,7 @@ is use for x:TypeArguments="system:Double" DO NOT REMOVE -->
         </Style>
         <Style Selector="^ /template/ ScrollContentPresenter#PART_ContentPresenter">
             <Setter Property="OpacityMask">
-                <MultiBinding Converter="{x:Static shadui:ScrollerToOpacityMask.Bottom}">
+                <MultiBinding Converter="{x:Static shadui:ScrollerToOpacityMask.Bottom}" x:CompileBindings="False">
                     <Binding Path="$parent[Panel;1].Children[2].Children[0].Value" />
                     <Binding Path="$parent[Panel;1].Children[2].Children[0].Maximum" />
                 </MultiBinding>

--- a/src/ShadUI/Controls/SimpleDropdown/SimpleDropdown.axaml.cs
+++ b/src/ShadUI/Controls/SimpleDropdown/SimpleDropdown.axaml.cs
@@ -160,14 +160,14 @@ public class SimpleDropdown : ItemsControl
 
     private void DetachEventHandlers()
     {
-        if (this.GetTemplateChildren().FirstOrDefault(x => x.Name == "PART_BorderContainer") is Border rootBorder)
+        if (this.GetTemplateDescendants().FirstOrDefault(x => x.Name == "PART_BorderContainer") is Border rootBorder)
         {
             rootBorder.PointerPressed -= OnRootBorderPressed;
             rootBorder.PointerReleased -= OnRootBorderReleased;
             rootBorder.PointerCaptureLost -= OnRootBorderCaptureLost;
         }
 
-        if (this.GetTemplateChildren().FirstOrDefault(x => x.Name == "PART_ItemsPresenter") is ItemsPresenter
+        if (this.GetTemplateDescendants().FirstOrDefault(x => x.Name == "PART_ItemsPresenter") is ItemsPresenter
             itemsPresenter)
         {
             itemsPresenter.AttachedToVisualTree -= OnItemsPresenterAttached;
@@ -265,20 +265,20 @@ public class SimpleDropdown : ItemsControl
     {
         base.OnLoaded(e);
         // Use GetTemplateChildren for OnLoaded since we don't have access to a proper INameScope
-        if (this.GetTemplateChildren().FirstOrDefault(x => x.Name == "PART_BorderContainer") is Border rootBorder)
+        if (this.GetTemplateDescendants().FirstOrDefault(x => x.Name == "PART_BorderContainer") is Border rootBorder)
         {
             rootBorder.PointerPressed += OnRootBorderPressed;
             rootBorder.PointerReleased += OnRootBorderReleased;
             rootBorder.PointerCaptureLost += OnRootBorderCaptureLost;
         }
 
-        if (this.GetTemplateChildren().FirstOrDefault(x => x.Name == "PART_ItemsPresenter") is ItemsPresenter
+        if (this.GetTemplateDescendants().FirstOrDefault(x => x.Name == "PART_ItemsPresenter") is ItemsPresenter
             itemsPresenter)
         {
             itemsPresenter.AttachedToVisualTree += OnItemsPresenterAttached;
         }
 
-        if (this.GetTemplateChildren().FirstOrDefault(x => x.Name == "PART_Border") is Border popupBorder)
+        if (this.GetTemplateDescendants().FirstOrDefault(x => x.Name == "PART_Border") is Border popupBorder)
         {
             popupBorder.PointerPressed += OnPopupBorderPressed;
         }

--- a/src/ShadUI/Controls/TextBox/TextBox.axaml
+++ b/src/ShadUI/Controls/TextBox/TextBox.axaml
@@ -11,20 +11,20 @@
             <StackPanel Spacing="16" Width="250 ">
                 <TextBox
                     Classes="Clearable"
-                    UseFloatingWatermark="True"
-                    Watermark="First Name" />
+                    UseFloatingPlaceholder="True"
+                    PlaceholderText="First Name" />
                 <TextBox
                     Classes="Clearable"
-                    UseFloatingWatermark="True"
-                    Watermark="Last Name" />
+                    UseFloatingPlaceholder="True"
+                    PlaceholderText="Last Name" />
                 <TextBox
                     Classes="Clearable"
                     Text="john"
-                    Watermark="Username" />
+                    PlaceholderText="Username" />
                 <TextBox
                     Classes="Clearable"
                     Text="12321"
-                    Watermark="Search here..."
+                    PlaceholderText="Search here..."
                     shadui:ControlAssist.Label="Search">
                     <TextBox.InnerRightContent>
                         <PathIcon
@@ -38,11 +38,11 @@
                     Classes="ClearablePassword"
                     PasswordChar="•"
                     Text="12321"
-                    Watermark="Enter password"
+                    PlaceholderText="Enter password"
                     shadui:ControlAssist.Label="Password" />
                 <TextBox
                     AcceptsReturn="True"
-                    Watermark="Description"
+                    PlaceholderText="Description"
                     shadui:ControlAssist.Height="250"
                     shadui:ControlAssist.Hint="This is hint"
                     shadui:ControlAssist.Label="Description" />
@@ -136,10 +136,10 @@
                     <TextBlock
                         Classes="Small"
                         Cursor="Arrow"
-                        IsVisible="{TemplateBinding UseFloatingWatermark}"
+                        IsVisible="{TemplateBinding UseFloatingPlaceholder}"
                         Margin="0,0,0,6"
                         Name="PART_Label"
-                        Text="{TemplateBinding Watermark}" />
+                        Text="{TemplateBinding PlaceholderText}" />
                     <DataValidationErrors Focusable="False">
                         <StackPanel>
                             <Border
@@ -167,22 +167,18 @@
                                             <TextBlock
                                                 HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                 Margin="{TemplateBinding Padding}"
-                                                Name="Watermark"
+                                                Name="Placeholder"
                                                 Opacity="0.5"
-                                                Text="{TemplateBinding Watermark}"
+                                                Text="{TemplateBinding PlaceholderText}"
                                                 TextAlignment="{TemplateBinding TextAlignment}"
                                                 TextWrapping="{TemplateBinding TextWrapping}"
                                                 VerticalAlignment="{TemplateBinding VerticalContentAlignment}">
                                                 <TextBlock.IsVisible>
                                                     <MultiBinding Converter="{x:Static BoolConverters.And}">
-                                                        <CompiledBinding
-                                                            Converter="{x:Static StringConverters.IsNullOrEmpty}"
-                                                            ElementName="PART_TextPresenter"
-                                                            Path="PreeditText" />
-                                                        <CompiledBinding
-                                                            Converter="{x:Static StringConverters.IsNullOrEmpty}"
-                                                            Path="Text"
-                                                            RelativeSource="{RelativeSource TemplatedParent}" />
+                                                        <Binding Path="#PART_TextPresenter.PreeditText"
+                                                                 Converter="{x:Static StringConverters.IsNullOrEmpty}" />
+                                                        <Binding Path="$parent[TextBox].Text"
+                                                                 Converter="{x:Static StringConverters.IsNullOrEmpty}" />
                                                     </MultiBinding>
                                                 </TextBlock.IsVisible>
                                             </TextBlock>

--- a/src/ShadUI/Controls/TimeInput/TimeInput.axaml
+++ b/src/ShadUI/Controls/TimeInput/TimeInput.axaml
@@ -135,7 +135,7 @@
                                         Text="{TemplateBinding HourString,
                                                                Mode=TwoWay}"
                                         Theme="{StaticResource InputBoxTheme}"
-                                        Watermark="hh"
+                                        PlaceholderText="hh"
                                         shadui:ElementAssist.FocusOnLoad="{TemplateBinding shadui:ElementAssist.FocusOnLoad}" />
                                     <TextBlock
                                         FontSize="18"
@@ -151,7 +151,7 @@
                                         Text="{TemplateBinding MinuteString,
                                                                Mode=TwoWay}"
                                         Theme="{StaticResource InputBoxTheme}"
-                                        Watermark="mm" />
+                                        PlaceholderText="mm" />
                                     <TextBlock
                                         FontSize="18"
                                         Grid.Column="3"
@@ -168,7 +168,7 @@
                                         Text="{TemplateBinding SecondString,
                                                                Mode=TwoWay}"
                                         Theme="{StaticResource InputBoxTheme}"
-                                        Watermark="ss" />
+                                        PlaceholderText="ss" />
                                     <ToggleButton
                                         Grid.Column="5"
                                         IsVisible="{TemplateBinding ClockIdentifier,

--- a/src/ShadUI/Controls/TimeInput/TimeInput.axaml.cs
+++ b/src/ShadUI/Controls/TimeInput/TimeInput.axaml.cs
@@ -204,7 +204,7 @@ public class TimeInput : TemplatedControl
     private bool _updating;
     private bool _fromInput;
 
-    private void OnInputChanged(object sender, TextChangedEventArgs e)
+    private void OnInputChanged(object? sender, TextChangedEventArgs e)
     {
         if (sender is not TextBox textBox || !_fromInput) return;
 
@@ -221,7 +221,7 @@ public class TimeInput : TemplatedControl
         nextTextBox?.SelectAll();
     }
 
-    private void OnTextBoxLostFocus(object sender, RoutedEventArgs e)
+    private void OnTextBoxLostFocus(object? sender, RoutedEventArgs e)
     {
         InputFocus = false;
 
@@ -254,7 +254,7 @@ public class TimeInput : TemplatedControl
         textBox.Text = value.ToString().PadLeft(2, '0');
     }
 
-    private void OnToggleButtonCheckChanged(object sender, RoutedEventArgs e)
+    private void OnToggleButtonCheckChanged(object? sender, RoutedEventArgs e)
     {
         if (sender is not ToggleButton toggleButton) return;
 

--- a/src/ShadUI/Controls/Toast/ToastHost.axaml.cs
+++ b/src/ShadUI/Controls/Toast/ToastHost.axaml.cs
@@ -159,12 +159,12 @@ public class ToastHost : ItemsControl
         manager.OnAllToastsDismissed -= ManagerOnAllToastsDismissed;
     }
 
-    private void ManagerOnToastDismissed(object sender, Toast toast)
+    private void ManagerOnToastDismissed(object? sender, Toast toast)
     {
         ClearToast(toast);
     }
 
-    private void ManagerOnAllToastsDismissed(object sender, EventArgs e)
+    private void ManagerOnAllToastsDismissed(object? sender, EventArgs e)
     {
         foreach (var toast in Items)
         {
@@ -172,7 +172,7 @@ public class ToastHost : ItemsControl
         }
     }
 
-    private void ManagerOnToastQueued(object sender, Toast toast)
+    private void ManagerOnToastQueued(object? sender, Toast toast)
     {
         if (MaxToasts <= 0) return;
 

--- a/src/ShadUI/Controls/Window/Window.axaml
+++ b/src/ShadUI/Controls/Window/Window.axaml
@@ -54,8 +54,7 @@
         <Setter Property="Margin" Value="0" />
         <Setter Property="Background" Value="{DynamicResource WindowBackgroundColor}" />
         <Setter Property="TransparencyLevelHint" Value="Transparent" />
-        <Setter Property="SystemDecorations" Value="{OnPlatform Full, Linux=None, x:TypeArguments=SystemDecorations}" />
-        <Setter Property="ExtendClientAreaChromeHints" Value="PreferSystemChrome" />
+        <Setter Property="WindowDecorations" Value="{OnPlatform BorderOnly, macOS=Full, Linux=None, x:TypeArguments=WindowDecorations}" />
         <Setter Property="ExtendClientAreaToDecorationsHint" Value="True" />
         <Setter Property="TextElement.Foreground" Value="{DynamicResource ForegroundColor}" />
         <Setter Property="BorderThickness" Value="1" />
@@ -69,18 +68,8 @@
                     ClipToBounds="True"
                     CornerRadius="{TemplateBinding RootCornerRadius}"
                     Margin="{TemplateBinding Margin}">
-                    <VisualLayerManager IsHitTestVisible="True">
-                        <VisualLayerManager.ChromeOverlayLayer>
-                            <ItemsControl ItemsSource="{CompiledBinding Hosts, RelativeSource={RelativeSource AncestorType={x:Type shadui:Window}}}">
-                                <ItemsControl.ItemsPanel>
-                                    <ItemsPanelTemplate>
-                                        <Panel />
-                                    </ItemsPanelTemplate>
-                                </ItemsControl.ItemsPanel>
-                            </ItemsControl>
-                        </VisualLayerManager.ChromeOverlayLayer>
-                        <Panel Name="PART_Root">
-                            <DockPanel LastChildFill="True">
+                    <Panel Name="PART_Root">
+                        <DockPanel LastChildFill="True">
                                 <Panel DockPanel.Dock="Top">
                                     <Panel.Styles>
                                         <Style Selector="shadui|Window[ShowBottomBorder=True] /template/ Border#BottomBorder">
@@ -198,9 +187,15 @@
                                     HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                                     IsHitTestVisible="True"
                                     VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
-                            </DockPanel>
-                        </Panel>
-                    </VisualLayerManager>
+                        </DockPanel>
+                        <ItemsControl ItemsSource="{CompiledBinding Hosts, RelativeSource={RelativeSource AncestorType={x:Type shadui:Window}}}">
+                            <ItemsControl.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <Panel />
+                                </ItemsPanelTemplate>
+                            </ItemsControl.ItemsPanel>
+                        </ItemsControl>
+                    </Panel>
                 </Border>
             </ControlTemplate>
         </Setter>

--- a/src/ShadUI/Extensions/ApplicationExt.cs
+++ b/src/ShadUI/Extensions/ApplicationExt.cs
@@ -27,7 +27,7 @@ internal static class ApplicationExt
         if (app.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) return desktop.MainWindow;
         if (app.ApplicationLifetime is ISingleViewApplicationLifetime viewApp)
         {
-            var visualRoot = viewApp.MainView?.GetVisualRoot();
+            var visualRoot = viewApp.MainView?.GetPresentationSource()?.RootVisual;
             return visualRoot as TopLevel;
         }
 

--- a/src/ShadUI/Extensions/WindowExt.cs
+++ b/src/ShadUI/Extensions/WindowExt.cs
@@ -347,8 +347,8 @@ public static class WindowExt
         void RaiseResize(object? sender, PointerPressedEventArgs e)
         {
             if (!window.CanResize) return;
-            if (sender is not Border { Tag: string edge }) return;
-            if (window.GetVisualRoot() is not Window w) return;
+            if (sender is not Border {Tag: string edge}) return;
+            if (window.GetPresentationSource()?.RootVisual is not Window w) return;
 
             var windowEdge = edge switch
             {

--- a/src/ShadUI/ShadUI.csproj
+++ b/src/ShadUI/ShadUI.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netstandard2.1</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <Version>0.0.1</Version>
         <FileVersion>0.0.1</FileVersion>
@@ -23,14 +23,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Avalonia" Version="11.3.10" />
-        <PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.3.10" />
+        <PackageReference Include="Avalonia" Version="12.0.2"/>
+        <PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.0.2"/>
+        <PackageReference Include="Avalonia.Themes.Simple" Version="12.0.2"/>
+        <PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0"/>
         <PackageReference Include="MinVer" Version="7.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Avalonia.Themes.Simple" Version="11.3.10" />
-        <PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.10" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/src/ShadUI/Themes/ThemeWatcher.cs
+++ b/src/ShadUI/Themes/ThemeWatcher.cs
@@ -34,7 +34,7 @@ public class ThemeWatcher
     /// <summary>
     ///     Handles theme change events and updates the current theme colors.
     /// </summary>
-    private void OnThemeChanged(object sender, EventArgs e)
+    private void OnThemeChanged(object? sender, EventArgs e)
     {
         var colors = GetThemeColors();
         ThemeColors = colors;

--- a/src/ShadUI/Utilities/SmoothScrollController.cs
+++ b/src/ShadUI/Utilities/SmoothScrollController.cs
@@ -13,7 +13,7 @@ namespace ShadUI;
 internal sealed class SmoothScrollController
 {
     private readonly ScrollViewer _instance;
-    private IRenderRoot? _visualRoot;
+    private Visual? _visualRoot;
     private TopLevel? _topLevel;
 
     private double _targetX, _currentX;
@@ -78,8 +78,8 @@ internal sealed class SmoothScrollController
 
         var source = e.Source as Visual;
         
-        var sourceRoot = source?.GetVisualRoot();
-        _visualRoot ??= _instance.GetVisualRoot();
+        var sourceRoot = source?.GetPresentationSource()?.RootVisual;
+        _visualRoot ??= _instance.GetPresentationSource()?.RootVisual;
 
         if (sourceRoot != _visualRoot)
             return; // this event is from a popup/flyout. TRAP IT!!! >:)


### PR DESCRIPTION
I changed as little as possible that was needed for Avalonia 12. I love using this UI and wanted to move my app to Avalonia 12 to see the rendering improvements. 

## Changes
- Project files updated where necessary (versions & packages)
- App.axaml.cs removed DisableAvaloniaDataAnnotationValidation - see https://docs.avaloniaui.net/docs/avalonia12-breaking-changes#binding-plugins-removed
- Added default typeface for LiveCharts (see Program.cs)
- Updated Dashboard to prevent crashing when switching themes or returning due to typeface loading and unstable paint instances
- Added UseHarfBuzz (noticed a swallowed exception referencing it after upgrading to Avalonia 12 - https://docs.avaloniaui.net/docs/avalonia12-breaking-changes#configurable-text-shaper)
- Various updates to Watermark changed to Placeholder equivalents
- GotFocusEventArgs changed to FocusChangedEventArgs per https://docs.avaloniaui.net/docs/avalonia12-breaking-changes#focus-handling
- Multiple CompiledBinding updates per https://docs.avaloniaui.net/docs/avalonia12-breaking-changes#binding-class-hierarchy-changes
- Window updates to utilize new WindowDecorations and the removal of VisualLayerManager.ChromeOverlayLayer - see https://docs.avaloniaui.net/docs/avalonia12-breaking-changes#window-decorations
- GetVisualRoot() changed to GetPresentationSource().RootVisual per https://docs.avaloniaui.net/docs/avalonia12-breaking-changes#toplevel

## TODO
- [ ] Bump ShadUI.csproj version to 0.2.0?
- [ ] Bump ShadUI.Demo.csproj to 1.1.2?