### PR TITLE
fix(window): added new property ShowAvaloniaFullscreenPopover

### DIFF
--- a/src/ShadUI/Controls/Window/Window.axaml
+++ b/src/ShadUI/Controls/Window/Window.axaml
@@ -8,6 +8,14 @@
         <ResourceInclude Source="avares://ShadUI/Controls/Constants.axaml" />
     </ResourceDictionary.MergedDictionaries>
 
+    <ControlTheme TargetType="WindowDrawnDecorations" x:Key="ShadUiSuppressedDecorationsTheme">
+        <Setter Property="Template">
+            <WindowDrawnDecorationsTemplate>
+                <WindowDrawnDecorationsContent />
+            </WindowDrawnDecorationsTemplate>
+        </Setter>
+    </ControlTheme>
+
     <ControlTheme TargetType="Button" x:Key="WindowButtonStyle">
         <Setter Property="VerticalContentAlignment" Value="Center" />
         <Setter Property="HorizontalContentAlignment" Value="Center" />
@@ -313,6 +321,9 @@
         </Style>
         <Style Selector="^ /template/ StackPanel#ButtonsPanel">
             <Setter Property="MinHeight" Value="32" />
+        </Style>
+        <Style Selector="^[ShowAvaloniaFullscreenPopover=False]">
+            <Setter Property="WindowDecorationsTheme" Value="{StaticResource ShadUiSuppressedDecorationsTheme}" />
         </Style>
     </ControlTheme>
 </ResourceDictionary>

--- a/src/ShadUI/Controls/Window/Window.axaml.cs
+++ b/src/ShadUI/Controls/Window/Window.axaml.cs
@@ -184,6 +184,25 @@ public class Window : Avalonia.Controls.Window
     }
 
     /// <summary>
+    ///     Whether to show Avalonia's built-in fullscreen popover — the top-edge chrome with
+    ///     title, exit-fullscreen, and close buttons that auto-appears when the pointer reaches
+    ///     the top of the screen if WindowState is FullScreen.
+    ///     Set to <c>true</c> when hiding the ShadUI title bar in fullscreen and relying on the
+    ///     framework popover for the exit affordance.
+    /// </summary>
+    public static readonly StyledProperty<bool> ShowAvaloniaFullscreenPopoverProperty =
+        AvaloniaProperty.Register<Window, bool>(nameof(ShowAvaloniaFullscreenPopover));
+
+    /// <summary>
+    ///     Gets or sets the value of the <see cref="ShowAvaloniaFullscreenPopoverProperty" />.
+    /// </summary>
+    public bool ShowAvaloniaFullscreenPopover
+    {
+        get => GetValue(ShowAvaloniaFullscreenPopoverProperty);
+        set => SetValue(ShowAvaloniaFullscreenPopoverProperty, value);
+    }
+
+    /// <summary>
     ///     Whether to enable move.
     /// </summary>
     public static readonly StyledProperty<bool> CanMoveProperty =


### PR DESCRIPTION
This is my assumption at what you would want @accntech - if not, check out this PR on how I fixed it.

- New property `ShowAvaloniaFullscreenPopover` defaulted to `false` to suppress Avalonia exit affordance. Just in case a user wants a truly full screen application and they hide their custom ShadUI title bar.

Usage if a user wants Avalonia's full screen exit affordance:

```xaml
<shadui:Window ShowAvaloniaFullscreenPopover="True">
```

### Tested

- [x] Windows 10 22H2
- [x] Windows 11 25H2
- [x] Fedora Linux 44 - KDE Plasma 6.6.4
  - Wasn't an issue originally, but checked just in case
- [ ] macOS Sequoia 15
- [ ] macOS Tahoe 26

> Currently working on setting up two macOS environments

---

Fixes #82 