### PR TITLE
fix: replace StackPanel with Grid in TabControl Template to support internal ScrollViewer

### DIFF
--- a/src/ShadUI/Controls/TabControl/TabControl.axaml
+++ b/src/ShadUI/Controls/TabControl/TabControl.axaml
@@ -77,7 +77,7 @@
                     CornerRadius="{TemplateBinding CornerRadius}"
                     HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
                     VerticalAlignment="{TemplateBinding VerticalAlignment}">
-                    <StackPanel Spacing="8">
+                    <Grid RowDefinitions="Auto,8,*">
                         <LayoutTransformControl
                             DockPanel.Dock="{TemplateBinding TabStripPlacement}"
                             HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
@@ -114,14 +114,14 @@
                                 </Panel>
                             </Border>
                         </LayoutTransformControl>
-                        <ContentPresenter
+                        <ContentPresenter Grid.Row="2"
                             Content="{TemplateBinding SelectedContent}"
                             ContentTemplate="{TemplateBinding SelectedContentTemplate}"
                             HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
                             Margin="{TemplateBinding Padding}"
                             Name="PART_SelectedContentHost"
                             VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}" />
-                    </StackPanel>
+                    </Grid>
                 </Border>
             </ControlTemplate>
         </Setter>


### PR DESCRIPTION
In the current ControlTemplate of TabControl, the content presenter is wrapped within a StackPanel. This causes an issue where a ScrollViewer placed inside a TabItem fails to function correctly because StackPanel provides infinite space to its children, preventing the ScrollViewer from calculating its viewport size.

This PR replaces the StackPanel with a Grid to ensure that content correctly fills the available space and allows ScrollViewer to trigger scrolling as expected.

I have tested the following XAML, and the ScrollViewer now scrolls correctly:

<Grid RowDefinitions="*">

    <TabControl>
        <TabControl.Items>
            <TabItem Header="Preview">
                <ScrollViewer 
                    shadui:SmoothScrollAssist.IsEnabled="True"
                    shadui:SmoothScrollAssist.BaseStepSize="70"
                    shadui:SmoothScrollAssist.SmoothingFactor="20" Margin="20 20 20 0">

                    <Border Height="2000">
                        <TextBlock Classes="h1" VerticalAlignment="Center" HorizontalAlignment="Center">Content</TextBlock>
                    </Border>

                </ScrollViewer>
            </TabItem>

            <TabItem Header="Code">       

            </TabItem>
        </TabControl.Items>
    </TabControl>    

</Grid>