### PR TITLE
fix(NumericUpDownAssist) & fix(SmoothScrollController)

### DIFF
--- a/src/ShadUI/AttachedProperties/NumericUpDownAssist.cs
+++ b/src/ShadUI/AttachedProperties/NumericUpDownAssist.cs
@@ -96,11 +96,14 @@ public class NumericUpDownAssist
         {
             TextBox = textBox,
             TextInputHandler = OnTextInput,
-            KeyDownHandler = OnKeyDown
+            KeyDownHandler = OnKeyDown,
+            PointerWheelHandler = OnPointerWheelChanged
         });
 
         textBox.AddHandler(InputElement.TextInputEvent, OnTextInput, RoutingStrategies.Tunnel);
-        textBox.KeyDown += OnKeyDown;
+        textBox.AddHandler(InputElement.KeyDownEvent, OnKeyDown, RoutingStrategies.Tunnel);
+        numericUpDown.AddHandler(InputElement.PointerWheelChangedEvent, OnPointerWheelChanged,
+            RoutingStrategies.Bubble, true);
         return;
 
         void OnTextInput(object? sender, TextInputEventArgs e)
@@ -144,7 +147,25 @@ public class NumericUpDownAssist
 
         void OnKeyDown(object? sender, KeyEventArgs e)
         {
-            // Reserved for future key filtering if needed
+            if (e.Key is not (Key.Up or Key.Down)) return;
+
+            var spinner = numericUpDown.FindControl<Spinner>("PART_Spinner");
+            if (spinner is null || !numericUpDown.AllowSpin) return;
+
+            var direction = e.Key == Key.Up ? SpinDirection.Increase : SpinDirection.Decrease;
+            spinner.RaiseEvent(new SpinEventArgs(Spinner.SpinEvent, direction));
+            e.Handled = true;
+        }
+
+        void OnPointerWheelChanged(object? sender, PointerWheelEventArgs e)
+        {
+            if (e.Delta.Y == 0 || !numericUpDown.AllowSpin || !numericUpDown.IsKeyboardFocusWithin) return;
+
+            var newValue = (numericUpDown.Value ?? 0) +
+                           (e.Delta.Y > 0 ? numericUpDown.Increment : -numericUpDown.Increment);
+
+            numericUpDown.Value = Math.Clamp(newValue, numericUpDown.Minimum, numericUpDown.Maximum);
+            e.Handled = true;
         }
     }
 
@@ -160,8 +181,11 @@ public class NumericUpDownAssist
                 handlers.TextBox.RemoveHandler(InputElement.TextInputEvent, handlers.TextInputHandler);
 
             if (handlers.KeyDownHandler is not null)
-                handlers.TextBox.KeyDown -= handlers.KeyDownHandler;
+                handlers.TextBox.RemoveHandler(InputElement.KeyDownEvent, handlers.KeyDownHandler);
         }
+
+        if (numericUpDown is not null && handlers.PointerWheelHandler is not null)
+            numericUpDown.RemoveHandler(InputElement.PointerWheelChangedEvent, handlers.PointerWheelHandler);
 
         numericUpDown?.ClearValue(InputHandlersProperty);
     }
@@ -171,6 +195,7 @@ public class NumericUpDownAssist
         public TextBox? TextBox { get; set; }
         public EventHandler<TextInputEventArgs>? TextInputHandler { get; set; }
         public EventHandler<KeyEventArgs>? KeyDownHandler { get; set; }
+        public EventHandler<PointerWheelEventArgs>? PointerWheelHandler { get; set; }
     }
 
     private static readonly AttachedProperty<InputHandlers> InputHandlersProperty =

--- a/src/ShadUI/Utilities/SmoothScrollController.cs
+++ b/src/ShadUI/Utilities/SmoothScrollController.cs
@@ -87,6 +87,9 @@ internal sealed class SmoothScrollController
         var isShiftPressed = (e.KeyModifiers & KeyModifiers.Shift) != 0;
         while (source is not null && source != _instance)
         {
+            if (source is ButtonSpinner { AllowSpin: true, IsKeyboardFocusWithin: true })
+                return;
+
             if (source is ScrollViewer inner && inner.IsVisible)
             {
                 var innerHasHorizontal = inner.HorizontalScrollBarVisibility != ScrollBarVisibility.Disabled;


### PR DESCRIPTION
I think I found three undocumented behaviors I traced through the Avalonia 12 source on GitHub. None are flagged in the breaking-changes doc:
  
  1. `TextBox.OnKeyDown` consumes Up/Down arrows (the keyboard arrow keys bug)

[src/Avalonia.Controls/TextBox.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/TextBox.cs) - search for case `Key.Up`: and case `Key.Down`: Both call `MoveVertical()` and set a local movement flag, then at the end:

```cs
if (handled || movement)
    e.Handled = true;
```

For a single-line TextBox, Up now moves the caret to position 0 and Down moves it to end -- the caret position changes, **movement = true**, and the event gets swallowed before bubbling to the `ButtonSpinner`. In Avalonia 11, `MoveVertical` was effectively a no-op for single-line `TextBoxes`.

  2. `NumericUpDown.OnSpinnerSpin` rejects wheel-originated spins (the mouse-wheel bug)

[src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/NumericUpDown/NumericUpDown.cs) - find `OnSpinnerSpin`:

```cs
var spin = !e.UsingMouseWheel;
spin |= ((TextBox != null) && TextBox.IsFocused);
if (spin) { e.Handled = true; OnSpin(e); }
```

For wheel events (UsingMouseWheel=true), spin only happens when `TextBox.IsFocused` returns true. In Avalonia 12, focus appears to land on a child element of the `TextBox` (likely the `TextPresenter`) rather than the `TextBox` itself, so `TextBox.IsFocused` is false even when the caret is visible. The `IsFocused` check passes in Avalonia 11 but not 12. This is why our keyboard fix works (it raises Spin without UsingMouseWheel, taking the !e.UsingMouseWheel = true branch and skipping the focus check entirely).

  3. `ButtonSpinner.OnPointerWheelChanged` raises with UsingMouseWheel=true

[src/Avalonia.Controls/ButtonSpinner.cs](https://github.com/AvaloniaUI/Avalonia/blob/master/src/Avalonia.Controls/ButtonSpinner.cs) - find `OnPointerWheelChanged`:

```cs
  var spinnerEventArgs = new SpinEventArgs(SpinEvent,
      (e.Delta.Y < 0) ? SpinDirection.Decrease : SpinDirection.Increase, true);
  //                                                                     ^^^^
  //                                                          UsingMouseWheel
```

This is the producer side of bug # 2 - the `ButtonSpinner` always tags wheel-originated spins, which feeds into the broken `IsFocused` check above.

  ---

Root cause summary: bugs # 1 and # 2 both stem from the same underlying Avalonia 12 change - focus and key handling shifted to inner template elements (TextPresenter, MoveVertical caret movement). Neither was called out as a breaking change because, in isolation, they look like correctness improvements. The regression only surfaces when you compose them via the **TextBox/ButtonSpinner/NumericUpDown** chain.

> This might be worth filing a ticket on AvaloniaUI's GitHub as a regression type bug

Fixes #88

---

### Tested

- [x] Windows 10 22H2
- [x] Windows 11 25H2
- [x] Fedora Linux 44 - KDE Plasma 6.6.4
- [ ] macOS Sequoia 15
- [ ] macOS Tahoe 26

> Currently working on setting up two macOS environments